### PR TITLE
fix(picklescan): preserve nested storage probe coverage

### DIFF
--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -2182,16 +2182,8 @@ class PyTorchZipScanner(BaseScanner):
                     short_sample,
                     candidate_is_prefix=entry.file_size > len(short_sample),
                 )
-                or PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
-                    sample,
-                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
-                    fail_closed_on_unknown_after_extension=True,
-                )
-                or PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
-                    short_sample,
-                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
-                    fail_closed_on_unknown_after_extension=True,
-                )
+                or PyTorchZipScanner._headerless_extension_candidate_should_scan_trusted_storage_sample(sample)
+                or PyTorchZipScanner._headerless_extension_candidate_should_scan_trusted_storage_sample(short_sample)
             )
             if should_scan:
                 charge_detection_probe_budget()
@@ -2522,6 +2514,23 @@ class PyTorchZipScanner(BaseScanner):
         if PyTorchZipScanner._contains_pickle_frame_opcode(sample):
             return False
         return _looks_like_proto0_or_1_pickle(sample, sample_is_prefix=True)
+
+    @staticmethod
+    def _headerless_extension_candidate_should_scan_trusted_storage_sample(sample: bytes) -> bool:
+        candidate = sample.lstrip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
+        if not candidate:
+            return False
+        if (
+            candidate[0] not in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+            and candidate[0] != _PICKLE_MARK_OPCODE_BYTE
+            and PyTorchZipScanner._complete_headerless_byte_literal_prefix_trailing(sample) is None
+        ):
+            return False
+        return PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+            sample,
+            [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+            fail_closed_on_unknown_after_extension=True,
+        )
 
     @staticmethod
     def _proto0_or_1_trusted_storage_probe_needs_expanded_sample(
@@ -3605,11 +3614,35 @@ class PyTorchZipScanner(BaseScanner):
 
     @staticmethod
     def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
-        if PyTorchZipScanner._raw_nested_security_pickle_text_marker_seen(value):
-            return True
-        if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
-            return True
+        if PyTorchZipScanner._budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value):
+            return False
         return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(value)
+
+    @staticmethod
+    def _budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value: bytes) -> bool:
+        if PyTorchZipScanner._raw_nested_proto0_global_ref_seen(value):
+            return False
+        extension_offsets = [
+            offset
+            for offset, byte in enumerate(value[:_MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES])
+            if byte in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+        ]
+        if len(extension_offsets) != 1:
+            return False
+        offset = extension_offsets[0]
+        prefix = value[:offset]
+        if not prefix or any(
+            byte not in _PROTO0_GLOBAL_NAME_BYTES and byte not in PROTO0_1_IGNORABLE_TRAILING_BYTES for byte in prefix
+        ):
+            return False
+        candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+        if PyTorchZipScanner._extension_candidate_after_exhausted_context_should_scan(candidate):
+            return False
+        if offset + len(candidate) < len(value):
+            return False
+        operand_len = {0x82: 1, 0x83: 2, 0x84: 4}[candidate[0]]
+        trailing = candidate[1 + operand_len :]
+        return not trailing or not trailing.strip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
 
     @staticmethod
     def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -159,6 +159,7 @@ _BINARY_EXTENSION_SECURITY_OPCODE_BYTES = b"\x82\x83\x84"
 _BINARY_SECURITY_OPCODE_REQUIRING_EXISTING_STACK_BYTES = b"\x81\x92\x93"
 _MAX_RAW_NESTED_PICKLE_CANDIDATES = 64
 _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES = 8 * 1024
+_MAX_NESTED_LITERAL_SCAN_DEPTH = 8
 _PROTO0_GLOBAL_OR_INST_PREFIX_WITHOUT_NEWLINE_RE = re.compile(rb"[ci][A-Za-z_][A-Za-z0-9_.]*")
 _REPEATED_PROTO0_INT_STREAM_RE = re.compile(rb"(?:I[+-]?\d+\n\.)+")
 _PROTO0_GLOBAL_NAME_START_BYTES = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_")
@@ -2067,6 +2068,10 @@ class PyTorchZipScanner(BaseScanner):
             not is_binary_pickle_candidate
             and not is_frame_first_candidate
             and data_start[0] in _HEADERLESS_BINARY_PICKLE_START_BYTES
+            and PyTorchZipScanner._headerless_binary_byte_literal_has_possible_size(
+                data_start,
+                entry_size=entry.file_size,
+            )
         )
         if (
             not is_binary_pickle_candidate
@@ -2120,8 +2125,8 @@ class PyTorchZipScanner(BaseScanner):
                         detection_probe_budget_charge_bytes = entry.file_size
                 elif (
                     PyTorchZipScanner._trivial_complete_pickle_prefix_has_only_padding(data_start)
-                    and defer_padding_probe is None
-                ):
+                    or PyTorchZipScanner._complete_headerless_byte_literal_prefix_has_only_padding(data_start)
+                ) and defer_padding_probe is None:
                     padding_probe_bytes = min(entry.file_size, _PICKLE_DISCOVERY_PADDING_PROBE_BYTES)
                     if padding_probe_bytes_remaining is None or padding_probe_bytes <= padding_probe_bytes_remaining[0]:
                         probe_bytes = padding_probe_bytes
@@ -2176,6 +2181,15 @@ class PyTorchZipScanner(BaseScanner):
             if should_scan:
                 charge_detection_probe_budget()
                 return True
+            if (
+                max_probe_bytes == _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
+                and defer_padding_probe is not None
+                and entry.file_size > len(sample)
+                and PyTorchZipScanner._complete_headerless_byte_literal_prefix_has_only_padding(sample)
+            ):
+                defer_padding_probe[0] = True
+                charge_deferred_probe_budget_before_skip()
+                return False
             charge_deferred_probe_budget_before_skip()
             return False
         if is_frame_first_candidate:
@@ -2611,7 +2625,14 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _trailing_pickle_probe_should_scan(trailing: bytes, *, sample_is_prefix: bool) -> bool:
+    def _trailing_pickle_probe_should_scan(
+        trailing: bytes,
+        *,
+        sample_is_prefix: bool,
+        nested_literal_depth: int = 0,
+    ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         candidate = trailing.lstrip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
         if not candidate:
             return False
@@ -2633,6 +2654,7 @@ class PyTorchZipScanner(BaseScanner):
         if PyTorchZipScanner._trailing_candidate_has_raw_nested_security_pickle(
             candidate,
             sample_is_prefix=sample_is_prefix,
+            nested_literal_depth=nested_literal_depth,
         ):
             return True
         if PyTorchZipScanner._malformed_separator_proto0_literal_has_nested_security_pickle(candidate):
@@ -2731,11 +2753,17 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _trivial_complete_pickle_prefix_trailing_should_scan(sample: bytes, *, sample_is_prefix: bool) -> bool:
+    def _trivial_complete_pickle_prefix_trailing_should_scan(
+        sample: bytes,
+        *,
+        sample_is_prefix: bool,
+        nested_literal_depth: int = 0,
+    ) -> bool:
         trailing = PyTorchZipScanner._trivial_complete_pickle_prefix_trailing(sample)
         return trailing is not None and PyTorchZipScanner._trailing_pickle_probe_should_scan(
             trailing,
             sample_is_prefix=sample_is_prefix,
+            nested_literal_depth=nested_literal_depth,
         )
 
     @staticmethod
@@ -2846,6 +2874,11 @@ class PyTorchZipScanner(BaseScanner):
         return trailing is not None and not trailing.strip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
 
     @staticmethod
+    def _complete_headerless_byte_literal_prefix_has_only_padding(sample: bytes) -> bool:
+        trailing = PyTorchZipScanner._complete_headerless_byte_literal_prefix_trailing(sample)
+        return trailing is not None and not trailing.strip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
+
+    @staticmethod
     def _trivial_complete_pickle_prefix_has_only_nul_padding(sample: bytes) -> bool:
         trailing = PyTorchZipScanner._trivial_complete_pickle_prefix_trailing(sample)
         return trailing is not None and bool(trailing) and not trailing.strip(b"\x00")
@@ -2911,7 +2944,36 @@ class PyTorchZipScanner(BaseScanner):
         return None
 
     @staticmethod
-    def _complete_trivial_literal_pickle_has_nested_security_pickle(sample: bytes) -> bool:
+    def _complete_headerless_byte_literal_prefix_trailing(sample: bytes) -> bytes | None:
+        if not sample or sample[0] not in _PICKLE_BINARY_BYTE_LITERAL_START_BYTES:
+            return None
+        opcode_count = 0
+        try:
+            for opcode, _arg, pos in pickletools.genops(sample):
+                opcode_count += 1
+                if pos is None:
+                    continue
+                if opcode_count == 1:
+                    if opcode.name not in _PICKLE_BINARY_BYTE_LITERAL_OPCODES:
+                        return None
+                elif opcode.name == "STOP":
+                    if opcode_count != 2:
+                        return None
+                    return sample[pos + 1 :]
+                else:
+                    return None
+        except Exception:
+            return None
+        return None
+
+    @staticmethod
+    def _complete_trivial_literal_pickle_has_nested_security_pickle(
+        sample: bytes,
+        *,
+        nested_literal_depth: int = 0,
+    ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         cursor = 0
         stream = io.BytesIO(sample)
         while cursor < len(sample):
@@ -2939,7 +3001,11 @@ class PyTorchZipScanner(BaseScanner):
                         if opcode_count < 2 or active_frame_end > len(sample):
                             return False
                         if any(
-                            PyTorchZipScanner._literal_value_has_storage_scan_signal(value) for value in literal_values
+                            PyTorchZipScanner._literal_value_has_storage_scan_signal(
+                                value,
+                                nested_literal_depth=nested_literal_depth + 1,
+                            )
+                            for value in literal_values
                         ):
                             return True
                         cursor = pos + 1
@@ -2955,11 +3021,20 @@ class PyTorchZipScanner(BaseScanner):
                 else:
                     return False
             except Exception:
-                return PyTorchZipScanner._complete_proto0_string_literal_has_nested_security_pickle(sample[cursor:])
+                return PyTorchZipScanner._complete_proto0_string_literal_has_nested_security_pickle(
+                    sample[cursor:],
+                    nested_literal_depth=nested_literal_depth,
+                )
         return False
 
     @staticmethod
-    def _complete_proto0_string_literal_has_nested_security_pickle(sample: bytes) -> bool:
+    def _complete_proto0_string_literal_has_nested_security_pickle(
+        sample: bytes,
+        *,
+        nested_literal_depth: int = 0,
+    ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         if not sample.startswith(b"S"):
             return False
         line_end = sample.find(b"\n", 1)
@@ -2981,7 +3056,10 @@ class PyTorchZipScanner(BaseScanner):
             if isinstance(decoded_literal, bytes)
             else PyTorchZipScanner._literal_str_to_scan_bytes(decoded_literal)
         )
-        return PyTorchZipScanner._literal_value_has_storage_scan_signal(literal_value)
+        return PyTorchZipScanner._literal_value_has_storage_scan_signal(
+            literal_value,
+            nested_literal_depth=nested_literal_depth + 1,
+        )
 
     @staticmethod
     def _literal_arg_bytes(opcode_name: str, value: Any) -> bytes | None:
@@ -3011,15 +3089,22 @@ class PyTorchZipScanner(BaseScanner):
         return bytes(output)
 
     @staticmethod
-    def _literal_value_has_nested_security_pickle(value: bytes) -> bool:
+    def _literal_value_has_nested_security_pickle(value: bytes, *, nested_literal_depth: int = 0) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         return PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(
-            value
-        ) or PyTorchZipScanner._literal_value_has_encoded_nested_security_pickle(value)
+            value,
+            nested_literal_depth=nested_literal_depth,
+        ) or PyTorchZipScanner._literal_value_has_encoded_nested_security_pickle(
+            value,
+            nested_literal_depth=nested_literal_depth,
+        )
 
     @staticmethod
-    def _literal_value_has_storage_scan_signal(value: bytes) -> bool:
+    def _literal_value_has_storage_scan_signal(value: bytes, *, nested_literal_depth: int = 0) -> bool:
         return PyTorchZipScanner._literal_value_has_nested_security_pickle(
-            value
+            value,
+            nested_literal_depth=nested_literal_depth,
         ) or PyTorchZipScanner._literal_value_has_suspicious_text(value)
 
     @staticmethod
@@ -3204,8 +3289,13 @@ class PyTorchZipScanner(BaseScanner):
 
     @staticmethod
     def _literal_value_has_raw_nested_security_pickle(
-        value: bytes, *, fail_closed_on_candidate_budget: bool = True
+        value: bytes,
+        *,
+        fail_closed_on_candidate_budget: bool = True,
+        nested_literal_depth: int = 0,
     ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         candidate_count = 0
         for offset, marker in enumerate(value):
             if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
@@ -3234,6 +3324,7 @@ class PyTorchZipScanner(BaseScanner):
                 and PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
                     candidate,
                     candidate_is_prefix=candidate_is_prefix,
+                    nested_literal_depth=nested_literal_depth + 1,
                 )
             ):
                 return True
@@ -3257,7 +3348,14 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _trailing_candidate_has_raw_nested_security_pickle(value: bytes, *, sample_is_prefix: bool) -> bool:
+    def _trailing_candidate_has_raw_nested_security_pickle(
+        value: bytes,
+        *,
+        sample_is_prefix: bool,
+        nested_literal_depth: int = 0,
+    ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         parse_attempt_count = 0
         for offset, marker in enumerate(value):
             if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
@@ -3280,6 +3378,7 @@ class PyTorchZipScanner(BaseScanner):
                 and PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
                     candidate,
                     candidate_is_prefix=candidate_is_prefix,
+                    nested_literal_depth=nested_literal_depth + 1,
                 )
             ):
                 return True
@@ -3525,13 +3624,29 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _raw_nested_binary_candidate_should_scan(candidate: bytes, *, candidate_is_prefix: bool) -> bool:
+    def _raw_nested_binary_candidate_should_scan(
+        candidate: bytes,
+        *,
+        candidate_is_prefix: bool,
+        nested_literal_depth: int = 0,
+    ) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         if PyTorchZipScanner._headerless_binary_pickle_prefix_needs_more_bytes(
             candidate,
             candidate_is_prefix=candidate_is_prefix,
         ):
             return True
-        if PyTorchZipScanner._complete_trivial_literal_pickle_has_nested_security_pickle(candidate):
+        if PyTorchZipScanner._complete_trivial_literal_pickle_has_nested_security_pickle(
+            candidate,
+            nested_literal_depth=nested_literal_depth,
+        ):
+            return True
+        if PyTorchZipScanner._trivial_complete_pickle_prefix_trailing_should_scan(
+            candidate,
+            sample_is_prefix=candidate_is_prefix,
+            nested_literal_depth=nested_literal_depth + 1,
+        ):
             return True
         if not PyTorchZipScanner._has_security_relevant_pickle_opcode(candidate):
             return False
@@ -3540,6 +3655,29 @@ class PyTorchZipScanner(BaseScanner):
         if PyTorchZipScanner._frame_first_trusted_storage_probe_should_scan(candidate):
             return True
         return candidate_is_prefix and PyTorchZipScanner._has_security_relevant_opcode_in_incomplete_frame(candidate)
+
+    @staticmethod
+    def _headerless_binary_byte_literal_has_possible_size(candidate: bytes, *, entry_size: int) -> bool:
+        if not candidate or candidate[0] not in _PICKLE_BINARY_BYTE_LITERAL_START_BYTES:
+            return True
+        opcode = candidate[0]
+        if opcode == ord("C"):
+            header_bytes = 2
+        elif opcode == ord("B"):
+            header_bytes = 5
+        else:
+            header_bytes = 9
+        if entry_size < header_bytes + 1:
+            return False
+        if len(candidate) < header_bytes:
+            return True
+        if opcode == ord("C"):
+            literal_size = candidate[1]
+        elif opcode == ord("B"):
+            literal_size = int.from_bytes(candidate[1:5], "little")
+        else:
+            literal_size = int.from_bytes(candidate[1:9], "little")
+        return header_bytes + literal_size + 1 <= entry_size
 
     @staticmethod
     def _headerless_binary_pickle_prefix_needs_more_bytes(candidate: bytes, *, candidate_is_prefix: bool) -> bool:
@@ -3574,7 +3712,9 @@ class PyTorchZipScanner(BaseScanner):
         return any(marker in value for marker in _RAW_NESTED_SECURITY_PICKLE_TEXT_MARKERS)
 
     @staticmethod
-    def _literal_value_has_encoded_nested_security_pickle(value: bytes) -> bool:
+    def _literal_value_has_encoded_nested_security_pickle(value: bytes, *, nested_literal_depth: int = 0) -> bool:
+        if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+            return True
         for match in _BASE64_NESTED_LITERAL_TOKEN_RE.finditer(value):
             token = _BASE64_NESTED_LITERAL_SEPARATOR_RE.sub(b"", match.group(0)).translate(
                 bytes.maketrans(b"-_", b"+/")
@@ -3586,13 +3726,18 @@ class PyTorchZipScanner(BaseScanner):
                 candidate_token = token[token_start:token_end]
                 for shift in range(min(4, len(candidate_token))):
                     shifted_token = candidate_token[shift:]
+                    shifted_token = shifted_token.rstrip(b"=")
+                    if not shifted_token:
+                        continue
                     shifted_token += b"=" * (-len(shifted_token) % 4)
                     try:
                         decoded = base64.b64decode(shifted_token, validate=True)
                     except (binascii.Error, ValueError):
                         continue
                     if decoded and PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(
-                        decoded, fail_closed_on_candidate_budget=False
+                        decoded,
+                        fail_closed_on_candidate_budget=False,
+                        nested_literal_depth=nested_literal_depth + 1,
                     ):
                         return True
         for match in _HEX_NESTED_LITERAL_TOKEN_RE.finditer(value):
@@ -3607,7 +3752,9 @@ class PyTorchZipScanner(BaseScanner):
                 except (binascii.Error, ValueError):
                     continue
                 if decoded and PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(
-                    decoded, fail_closed_on_candidate_budget=False
+                    decoded,
+                    fail_closed_on_candidate_budget=False,
+                    nested_literal_depth=nested_literal_depth + 1,
                 ):
                     return True
         return False

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -3543,7 +3543,8 @@ class PyTorchZipScanner(BaseScanner):
             if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
                 if recovered_extension_context:
                     if PyTorchZipScanner._has_executable_extension_opcode_before_stop(
-                        candidate
+                        candidate,
+                        fail_closed_on_unknown_after_extension=fail_closed_on_candidate_budget,
                     ) or PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
                         candidate,
                         candidate_is_prefix=candidate_is_prefix,
@@ -3553,6 +3554,7 @@ class PyTorchZipScanner(BaseScanner):
                 elif PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
                     candidate,
                     extension_parse_budget_remaining,
+                    fail_closed_on_unknown_after_extension=fail_closed_on_candidate_budget,
                 ):
                     return True
             if (

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -3614,6 +3614,8 @@ class PyTorchZipScanner(BaseScanner):
 
     @staticmethod
     def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
+        if PyTorchZipScanner._raw_nested_security_pickle_text_marker_seen(value):
+            return True
         if PyTorchZipScanner._budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value):
             return False
         return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(value)
@@ -3641,6 +3643,8 @@ class PyTorchZipScanner(BaseScanner):
         if offset + len(candidate) < len(value):
             return False
         operand_len = {0x82: 1, 0x83: 2, 0x84: 4}[candidate[0]]
+        if len(candidate) >= 1 + operand_len:
+            return False
         trailing = candidate[1 + operand_len :]
         return not trailing or not trailing.strip(PROTO0_1_IGNORABLE_TRAILING_BYTES)
 

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -2173,12 +2173,25 @@ class PyTorchZipScanner(BaseScanner):
             return False
         if is_headerless_binary_pickle_candidate:
             short_sample = sample[:_TRUSTED_STORAGE_PICKLE_PROBE_BYTES]
-            should_scan = PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
-                sample,
-                candidate_is_prefix=entry.file_size > len(sample),
-            ) or PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
-                short_sample,
-                candidate_is_prefix=entry.file_size > len(short_sample),
+            should_scan = (
+                PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
+                    sample,
+                    candidate_is_prefix=entry.file_size > len(sample),
+                )
+                or PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
+                    short_sample,
+                    candidate_is_prefix=entry.file_size > len(short_sample),
+                )
+                or PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+                    sample,
+                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                    fail_closed_on_unknown_after_extension=True,
+                )
+                or PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+                    short_sample,
+                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                    fail_closed_on_unknown_after_extension=True,
+                )
             )
             if should_scan:
                 charge_detection_probe_budget()
@@ -2192,6 +2205,12 @@ class PyTorchZipScanner(BaseScanner):
                 defer_padding_probe[0] = True
                 charge_deferred_probe_budget_before_skip()
                 return False
+            if (
+                max_probe_bytes > _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
+                and entry.file_size > len(sample)
+                and PyTorchZipScanner._complete_headerless_byte_literal_prefix_has_only_padding(sample)
+            ):
+                raise ValueError("trusted PyTorch storage padding probe limit reached")
             charge_deferred_probe_budget_before_skip()
             return False
         if is_frame_first_candidate:
@@ -2759,6 +2778,7 @@ class PyTorchZipScanner(BaseScanner):
         candidate: bytes,
         *,
         fail_closed_on_truncated_extension: bool = True,
+        fail_closed_on_unknown_after_extension: bool = False,
     ) -> bool:
         stack: list[str] = []
         memo: dict[str, str] = {}
@@ -2904,7 +2924,7 @@ class PyTorchZipScanner(BaseScanner):
                 return False
             message = str(error)
             if "opcode" in message and "unknown" in message:
-                return parsed_after_extension
+                return parsed_after_extension or fail_closed_on_unknown_after_extension
             if "pickle exhausted before seeing STOP" in message:
                 return fail_closed_on_truncated_extension
             return True
@@ -3489,10 +3509,7 @@ class PyTorchZipScanner(BaseScanner):
                     extension_parse_budget_remaining,
                 )
                 if exhausted_budget:
-                    candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-                    if PyTorchZipScanner._extension_candidate_after_exhausted_context_should_scan(candidate):
-                        return True
-                    continue
+                    return True
                 candidate_start = recovered_start
                 recovered_extension_context = True
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
@@ -3592,10 +3609,7 @@ class PyTorchZipScanner(BaseScanner):
             return True
         if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
             return True
-        return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(
-            value,
-            fail_closed_on_truncated_extension=False,
-        )
+        return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(value)
 
     @staticmethod
     def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
@@ -3774,6 +3788,7 @@ class PyTorchZipScanner(BaseScanner):
         parse_budget_remaining: list[int],
         *,
         fail_closed_on_truncated_extension: bool = True,
+        fail_closed_on_unknown_after_extension: bool = False,
     ) -> bool:
         search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
         search_start = 0
@@ -3794,16 +3809,13 @@ class PyTorchZipScanner(BaseScanner):
                 parse_budget_remaining,
             )
             if exhausted_budget:
-                candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-                if PyTorchZipScanner._extension_candidate_after_exhausted_context_should_scan(candidate):
-                    return True
-                search_start = offset + 1
-                continue
+                return True
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if PyTorchZipScanner._has_executable_extension_opcode_before_stop(
                 candidate,
                 fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
+                fail_closed_on_unknown_after_extension=fail_closed_on_unknown_after_extension,
             ):
                 return True
             if PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
@@ -3837,7 +3849,7 @@ class PyTorchZipScanner(BaseScanner):
                 search_start += 1
             candidate_start, stop_pos, exhausted_budget = parse_candidate(search_start)
             if exhausted_budget:
-                return offset, True
+                return search_start, True
             if candidate_start is not None:
                 return candidate_start, False
             if stop_pos is None or stop_pos < search_start:
@@ -3848,7 +3860,7 @@ class PyTorchZipScanner(BaseScanner):
         while mark >= window_start:
             candidate_start, _stop_pos, exhausted_budget = parse_candidate(mark)
             if exhausted_budget:
-                return offset, True
+                return mark, True
             if candidate_start is not None:
                 return candidate_start, False
             mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, mark)
@@ -4015,7 +4027,7 @@ class PyTorchZipScanner(BaseScanner):
             literal_size = int.from_bytes(candidate[1:5], "little")
         else:
             literal_size = int.from_bytes(candidate[1:9], "little")
-        return header_bytes + literal_size + 1 <= entry_size
+        return header_bytes + literal_size <= entry_size
 
     @staticmethod
     def _headerless_binary_pickle_prefix_needs_more_bytes(candidate: bytes, *, candidate_is_prefix: bool) -> bool:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -2776,6 +2776,16 @@ class PyTorchZipScanner(BaseScanner):
         def callable_is_extension(offset_from_top: int) -> bool:
             return len(stack) >= offset_from_top and stack[-offset_from_top] == "extension"
 
+        def last_mark_index() -> int:
+            try:
+                return len(stack) - 1 - stack[::-1].index("mark")
+            except ValueError:
+                return -1
+
+        def mark_target_is_extension() -> bool:
+            mark_index = last_mark_index()
+            return mark_index > 0 and stack[mark_index - 1] == "extension"
+
         try:
             for opcode, arg, _pos in pickletools.genops(candidate):
                 if opcode.name in _PICKLE_EXTENSION_OPCODES:
@@ -2815,7 +2825,20 @@ class PyTorchZipScanner(BaseScanner):
                     push("other")
                     continue
                 if opcode.name in {"APPENDS", "SETITEMS", "ADDITEMS"}:
+                    if mark_target_is_extension():
+                        return True
                     pop_until_mark()
+                    continue
+                if opcode.name == "APPEND":
+                    if callable_is_extension(2):
+                        return True
+                    pop()
+                    continue
+                if opcode.name == "SETITEM":
+                    if callable_is_extension(3):
+                        return True
+                    pop()
+                    pop()
                     continue
                 if opcode.name == "EMPTY_TUPLE":
                     push("other")
@@ -2848,10 +2871,7 @@ class PyTorchZipScanner(BaseScanner):
                     push("other")
                     continue
                 if opcode.name == "OBJ":
-                    try:
-                        mark_index = len(stack) - 1 - stack[::-1].index("mark")
-                    except ValueError:
-                        mark_index = -1
+                    mark_index = last_mark_index()
                     if mark_index >= 0 and mark_index + 1 < len(stack) and stack[mark_index + 1] == "extension":
                         return True
                     pop_until_mark()
@@ -3419,6 +3439,7 @@ class PyTorchZipScanner(BaseScanner):
         if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
             return True
         candidate_count = 0
+        extension_parse_budget_remaining = [_MAX_RAW_NESTED_PICKLE_CANDIDATES]
         for offset, marker in enumerate(value):
             if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
                 continue
@@ -3461,7 +3482,7 @@ class PyTorchZipScanner(BaseScanner):
                 marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
                 and PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
                     candidate,
-                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                    extension_parse_budget_remaining,
                 )
             ):
                 return True
@@ -3712,7 +3733,7 @@ class PyTorchZipScanner(BaseScanner):
                 return False
             if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
                 return True
-            candidate_start = offset - 1 if offset > 0 and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE else offset
+            candidate_start = PyTorchZipScanner._raw_nested_extension_candidate_start(value, offset)
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if PyTorchZipScanner._has_executable_extension_opcode_before_stop(candidate):
@@ -3724,6 +3745,14 @@ class PyTorchZipScanner(BaseScanner):
                 return True
             search_start = offset + 1
         return False
+
+    @staticmethod
+    def _raw_nested_extension_candidate_start(value: bytes, offset: int) -> int:
+        window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
+        stop = value.rfind(b".", window_start, offset)
+        mark_search_start = stop + 1 if stop >= 0 else window_start
+        mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), mark_search_start, offset)
+        return mark if mark >= 0 else offset
 
     @staticmethod
     def _raw_nested_binary_opcode_candidate_has_structural_signal(

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -156,8 +156,6 @@ _RAW_NESTED_SECURITY_PICKLE_START_BYTES = (
     _RAW_NESTED_TEXT_SECURITY_PICKLE_START_BYTES + _RAW_NESTED_BINARY_SECURITY_PICKLE_START_BYTES
 )
 _BINARY_EXTENSION_SECURITY_OPCODE_BYTES = b"\x82\x83\x84"
-_BINARY_EXTENSION_OPCODE_OPERAND_BYTES = {0x82: 1, 0x83: 2, 0x84: 4}
-_BINARY_EXTENSION_OPCODE_FOLLOWER_BYTES = b".)Rq\x85\x86\x87\x94\x95"
 _BINARY_SECURITY_OPCODE_REQUIRING_EXISTING_STACK_BYTES = b"\x81\x92\x93"
 _MAX_RAW_NESTED_PICKLE_CANDIDATES = 64
 _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES = 8 * 1024
@@ -3241,7 +3239,10 @@ class PyTorchZipScanner(BaseScanner):
                 return True
             if (
                 marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-                and PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(candidate)
+                and PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+                    candidate,
+                    [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                )
             ):
                 return True
             if (
@@ -3346,7 +3347,10 @@ class PyTorchZipScanner(BaseScanner):
             parse_budget_remaining,
         ):
             return True
-        if PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(value):
+        if PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+            value,
+            parse_budget_remaining,
+        ):
             return True
         if PyTorchZipScanner._raw_nested_binary_opcode_candidate_has_structural_signal(
             value,
@@ -3461,7 +3465,10 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _raw_nested_extension_opcode_candidate_has_structural_signal(value: bytes) -> bool:
+    def _raw_nested_extension_opcode_candidate_has_structural_signal(
+        value: bytes,
+        parse_budget_remaining: list[int],
+    ) -> bool:
         search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
         search_start = 0
         while search_start < search_limit:
@@ -3475,12 +3482,13 @@ class PyTorchZipScanner(BaseScanner):
             )
             if offset < 0:
                 return False
-            operand_len = _BINARY_EXTENSION_OPCODE_OPERAND_BYTES[value[offset]]
-            follower_offset = offset + 1 + operand_len
-            if (
-                follower_offset < search_limit
-                and follower_offset < len(value)
-                and value[follower_offset] in _BINARY_EXTENSION_OPCODE_FOLLOWER_BYTES
+            if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+                return True
+            candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+            candidate_is_prefix = offset + len(candidate) < len(value)
+            if PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
+                candidate,
+                candidate_is_prefix=candidate_is_prefix,
             ):
                 return True
             search_start = offset + 1

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -126,6 +126,8 @@ _PICKLE_SECURITY_RELEVANT_OPCODES = frozenset(
         "STACK_GLOBAL",
     }
 )
+_PICKLE_EXTENSION_OPCODES = frozenset({"EXT1", "EXT2", "EXT4"})
+_PICKLE_EXTENSION_EXECUTION_OPCODES = frozenset({"BUILD", "NEWOBJ", "NEWOBJ_EX", "OBJ", "REDUCE"})
 _PICKLE_OPCODE_BYTES = frozenset(ord(opcode.code) for opcode in pickletools.opcodes)
 _PROTO0_1_LITERAL_OPCODES = frozenset(
     {
@@ -2753,6 +2755,24 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
+    def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
+        extension_seen = False
+        try:
+            for opcode, _arg, _pos in pickletools.genops(candidate):
+                if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                    extension_seen = True
+                    continue
+                if opcode.name == "STOP":
+                    return False
+                if extension_seen and opcode.name in _PICKLE_EXTENSION_EXECUTION_OPCODES:
+                    return True
+                if opcode.name in {"POP", "POP_MARK"}:
+                    extension_seen = False
+        except Exception:
+            return False
+        return False
+
+    @staticmethod
     def _trivial_complete_pickle_prefix_trailing_should_scan(
         sample: bytes,
         *,
@@ -3585,6 +3605,8 @@ class PyTorchZipScanner(BaseScanner):
                 return True
             candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = offset + len(candidate) < len(value)
+            if PyTorchZipScanner._has_executable_extension_opcode_before_stop(candidate):
+                return True
             if PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
                 candidate,
                 candidate_is_prefix=candidate_is_prefix,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -2755,10 +2755,15 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
+    def _has_executable_extension_opcode_before_stop(
+        candidate: bytes,
+        *,
+        fail_closed_on_truncated_extension: bool = True,
+    ) -> bool:
         stack: list[str] = []
         memo: dict[str, str] = {}
         saw_extension_opcode = False
+        parsed_after_extension = False
 
         def push(value: str) -> None:
             stack.append(value)
@@ -2793,6 +2798,8 @@ class PyTorchZipScanner(BaseScanner):
                     saw_extension_opcode = True
                     push("extension")
                     continue
+                if saw_extension_opcode:
+                    parsed_after_extension = True
                 if opcode.name == "MARK":
                     push("mark")
                     continue
@@ -2892,8 +2899,15 @@ class PyTorchZipScanner(BaseScanner):
                 if opcode.stack_after:
                     for _ in opcode.stack_after:
                         push("other")
-        except Exception:
-            return saw_extension_opcode
+        except Exception as error:
+            if not saw_extension_opcode:
+                return False
+            message = str(error)
+            if "opcode" in message and "unknown" in message:
+                return parsed_after_extension
+            if "pickle exhausted before seeing STOP" in message:
+                return fail_closed_on_truncated_extension
+            return True
         return False
 
     @staticmethod
@@ -3454,13 +3468,33 @@ class PyTorchZipScanner(BaseScanner):
                 return PyTorchZipScanner._raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(
                     value[offset:]
                 )
-            candidate_start = (
-                offset - 1
-                if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-                and offset > 0
-                and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE
-                else offset
-            )
+            candidate_start = offset
+            recovered_extension_context = False
+            if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+                extension_window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
+                recover_extension_context = (
+                    value.rfind(
+                        bytes([_PICKLE_MARK_OPCODE_BYTE]),
+                        extension_window_start,
+                        offset,
+                    )
+                    >= extension_window_start
+                )
+            else:
+                recover_extension_context = False
+            if recover_extension_context:
+                recovered_start, exhausted_budget = PyTorchZipScanner._raw_nested_extension_candidate_start(
+                    value,
+                    offset,
+                    extension_parse_budget_remaining,
+                )
+                if exhausted_budget:
+                    candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+                    if PyTorchZipScanner._extension_candidate_after_exhausted_context_should_scan(candidate):
+                        return True
+                    continue
+                candidate_start = recovered_start
+                recovered_extension_context = True
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if marker == 0x80 and PyTorchZipScanner._looks_like_binary_pickle_prefix(
@@ -3480,14 +3514,21 @@ class PyTorchZipScanner(BaseScanner):
                 )
             ):
                 return True
-            if (
-                marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-                and PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+            if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+                if recovered_extension_context:
+                    if PyTorchZipScanner._has_executable_extension_opcode_before_stop(
+                        candidate
+                    ) or PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
+                        candidate,
+                        candidate_is_prefix=candidate_is_prefix,
+                        nested_literal_depth=nested_literal_depth + 1,
+                    ):
+                        return True
+                elif PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
                     candidate,
                     extension_parse_budget_remaining,
-                )
-            ):
-                return True
+                ):
+                    return True
             if (
                 marker in PROTO0_1_START_BYTES
                 and PyTorchZipScanner._has_security_relevant_pickle_opcode(candidate)
@@ -3549,7 +3590,12 @@ class PyTorchZipScanner(BaseScanner):
     def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
         if PyTorchZipScanner._raw_nested_security_pickle_text_marker_seen(value):
             return True
-        return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(value)
+        if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+            return True
+        return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(
+            value,
+            fail_closed_on_truncated_extension=False,
+        )
 
     @staticmethod
     def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
@@ -3589,7 +3635,11 @@ class PyTorchZipScanner(BaseScanner):
         return PyTorchZipScanner._raw_nested_security_pickle_candidate_has_structural_signal(value)
 
     @staticmethod
-    def _raw_nested_security_pickle_candidate_has_structural_signal(value: bytes) -> bool:
+    def _raw_nested_security_pickle_candidate_has_structural_signal(
+        value: bytes,
+        *,
+        fail_closed_on_truncated_extension: bool = True,
+    ) -> bool:
         parse_budget_remaining = [_MAX_RAW_NESTED_PICKLE_CANDIDATES]
         if PyTorchZipScanner._raw_nested_proto0_global_ref_seen(value):
             return True
@@ -3601,6 +3651,7 @@ class PyTorchZipScanner(BaseScanner):
         if PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
             value,
             parse_budget_remaining,
+            fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
         ):
             return True
         if PyTorchZipScanner._raw_nested_binary_opcode_candidate_has_structural_signal(
@@ -3615,7 +3666,9 @@ class PyTorchZipScanner(BaseScanner):
             return False
         marker = candidate[0]
         if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
-            return True
+            return fail_closed_on_truncated_extension or PyTorchZipScanner._has_complete_extension_opcode_stream(
+                candidate
+            )
         if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
             return True
         if marker == 0x80 and PyTorchZipScanner._looks_like_binary_pickle_prefix(
@@ -3719,6 +3772,8 @@ class PyTorchZipScanner(BaseScanner):
     def _raw_nested_extension_opcode_candidate_has_structural_signal(
         value: bytes,
         parse_budget_remaining: list[int],
+        *,
+        fail_closed_on_truncated_extension: bool = True,
     ) -> bool:
         search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
         search_start = 0
@@ -3739,10 +3794,17 @@ class PyTorchZipScanner(BaseScanner):
                 parse_budget_remaining,
             )
             if exhausted_budget:
-                return True
+                candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+                if PyTorchZipScanner._extension_candidate_after_exhausted_context_should_scan(candidate):
+                    return True
+                search_start = offset + 1
+                continue
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = candidate_start + len(candidate) < len(value)
-            if PyTorchZipScanner._has_executable_extension_opcode_before_stop(candidate):
+            if PyTorchZipScanner._has_executable_extension_opcode_before_stop(
+                candidate,
+                fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
+            ):
                 return True
             if PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
                 candidate,
@@ -3793,13 +3855,49 @@ class PyTorchZipScanner(BaseScanner):
         return offset, False
 
     @staticmethod
+    def _has_complete_extension_opcode_stream(candidate: bytes) -> bool:
+        saw_extension_opcode = False
+        try:
+            for opcode, _arg, _pos in pickletools.genops(candidate):
+                if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                    saw_extension_opcode = True
+                    continue
+                if opcode.name == "STOP":
+                    return saw_extension_opcode
+        except Exception:
+            return False
+        return False
+
+    @staticmethod
+    def _extension_candidate_after_exhausted_context_should_scan(candidate: bytes) -> bool:
+        return PyTorchZipScanner._has_complete_extension_opcode_stream(
+            candidate
+        ) or PyTorchZipScanner._has_executable_extension_opcode_before_stop(
+            candidate,
+            fail_closed_on_truncated_extension=False,
+        )
+
+    @staticmethod
     def _parsed_raw_nested_extension_candidate_start(
         value: bytes,
         start: int,
         offset: int,
     ) -> tuple[int | None, int | None]:
         parse_end = min(len(value), offset + 5)
-        live_mark: int | None = None
+        stack: list[int | None] = []
+
+        def pop_stack() -> None:
+            if stack:
+                stack.pop()
+
+        def pop_until_mark() -> None:
+            while stack:
+                if stack.pop() is not None:
+                    break
+
+        def live_mark() -> int | None:
+            return next((item for item in reversed(stack) if item is not None), None)
+
         try:
             for opcode, _arg, pos in pickletools.genops(value[start:parse_end]):
                 if pos is None:
@@ -3807,14 +3905,28 @@ class PyTorchZipScanner(BaseScanner):
                 absolute_pos = start + pos
                 if absolute_pos == offset:
                     if opcode.name in _PICKLE_EXTENSION_OPCODES:
-                        return (live_mark if live_mark is not None else offset), None
+                        mark = live_mark()
+                        return (mark if mark is not None else offset), None
                     return None, None
                 if absolute_pos > offset:
                     return start, None
                 if opcode.name == "STOP":
                     return None, absolute_pos
                 if opcode.name == "MARK":
-                    live_mark = absolute_pos
+                    stack.append(absolute_pos)
+                    continue
+                if opcode.name == "POP":
+                    pop_stack()
+                    continue
+                if opcode.name == "POP_MARK":
+                    pop_until_mark()
+                    continue
+                if opcode.stack_before:
+                    for _ in opcode.stack_before:
+                        pop_stack()
+                if opcode.stack_after:
+                    for _ in opcode.stack_after:
+                        stack.append(None)
         except Exception:
             return None, None
         return None, None

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -2758,6 +2758,7 @@ class PyTorchZipScanner(BaseScanner):
     def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
         stack: list[str] = []
         memo: dict[str, str] = {}
+        saw_extension_opcode = False
 
         def push(value: str) -> None:
             stack.append(value)
@@ -2789,6 +2790,7 @@ class PyTorchZipScanner(BaseScanner):
         try:
             for opcode, arg, _pos in pickletools.genops(candidate):
                 if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                    saw_extension_opcode = True
                     push("extension")
                     continue
                 if opcode.name == "MARK":
@@ -2891,7 +2893,7 @@ class PyTorchZipScanner(BaseScanner):
                     for _ in opcode.stack_after:
                         push("other")
         except Exception:
-            return False
+            return saw_extension_opcode
         return False
 
     @staticmethod
@@ -3731,9 +3733,13 @@ class PyTorchZipScanner(BaseScanner):
             )
             if offset < 0:
                 return False
-            if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+            candidate_start, exhausted_budget = PyTorchZipScanner._raw_nested_extension_candidate_start(
+                value,
+                offset,
+                parse_budget_remaining,
+            )
+            if exhausted_budget:
                 return True
-            candidate_start = PyTorchZipScanner._raw_nested_extension_candidate_start(value, offset)
             candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
             candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if PyTorchZipScanner._has_executable_extension_opcode_before_stop(candidate):
@@ -3747,12 +3753,71 @@ class PyTorchZipScanner(BaseScanner):
         return False
 
     @staticmethod
-    def _raw_nested_extension_candidate_start(value: bytes, offset: int) -> int:
+    def _raw_nested_extension_candidate_start(
+        value: bytes,
+        offset: int,
+        parse_budget_remaining: list[int],
+    ) -> tuple[int, bool]:
+        def parse_candidate(start: int) -> tuple[int | None, int | None, bool]:
+            if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+                return None, None, True
+            candidate_start, stop_pos = PyTorchZipScanner._parsed_raw_nested_extension_candidate_start(
+                value,
+                start,
+                offset,
+            )
+            return candidate_start, stop_pos, False
+
         window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
-        stop = value.rfind(b".", window_start, offset)
-        mark_search_start = stop + 1 if stop >= 0 else window_start
-        mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), mark_search_start, offset)
-        return mark if mark >= 0 else offset
+        search_start = window_start
+        while search_start <= offset:
+            while search_start < offset and value[search_start] in PROTO0_1_IGNORABLE_TRAILING_BYTES:
+                search_start += 1
+            candidate_start, stop_pos, exhausted_budget = parse_candidate(search_start)
+            if exhausted_budget:
+                return offset, True
+            if candidate_start is not None:
+                return candidate_start, False
+            if stop_pos is None or stop_pos < search_start:
+                break
+            search_start = stop_pos + 1
+
+        mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, offset)
+        while mark >= window_start:
+            candidate_start, _stop_pos, exhausted_budget = parse_candidate(mark)
+            if exhausted_budget:
+                return offset, True
+            if candidate_start is not None:
+                return candidate_start, False
+            mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, mark)
+        return offset, False
+
+    @staticmethod
+    def _parsed_raw_nested_extension_candidate_start(
+        value: bytes,
+        start: int,
+        offset: int,
+    ) -> tuple[int | None, int | None]:
+        parse_end = min(len(value), offset + 5)
+        live_mark: int | None = None
+        try:
+            for opcode, _arg, pos in pickletools.genops(value[start:parse_end]):
+                if pos is None:
+                    continue
+                absolute_pos = start + pos
+                if absolute_pos == offset:
+                    if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                        return (live_mark if live_mark is not None else offset), None
+                    return None, None
+                if absolute_pos > offset:
+                    return start, None
+                if opcode.name == "STOP":
+                    return None, absolute_pos
+                if opcode.name == "MARK":
+                    live_mark = absolute_pos
+        except Exception:
+            return None, None
+        return None, None
 
     @staticmethod
     def _raw_nested_binary_opcode_candidate_has_structural_signal(

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -127,8 +127,8 @@ _PICKLE_SECURITY_RELEVANT_OPCODES = frozenset(
     }
 )
 _PICKLE_EXTENSION_OPCODES = frozenset({"EXT1", "EXT2", "EXT4"})
-_PICKLE_EXTENSION_EXECUTION_OPCODES = frozenset({"BUILD", "NEWOBJ", "NEWOBJ_EX", "OBJ", "REDUCE"})
 _PICKLE_OPCODE_BYTES = frozenset(ord(opcode.code) for opcode in pickletools.opcodes)
+_PICKLE_MARK_OPCODE_BYTE = ord("(")
 _PROTO0_1_LITERAL_OPCODES = frozenset(
     {
         "STRING",
@@ -2756,18 +2756,120 @@ class PyTorchZipScanner(BaseScanner):
 
     @staticmethod
     def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
-        extension_seen = False
+        stack: list[str] = []
+        memo: dict[str, str] = {}
+
+        def push(value: str) -> None:
+            stack.append(value)
+
+        def pop() -> str:
+            return stack.pop() if stack else "other"
+
+        def pop_until_mark() -> None:
+            while stack:
+                if stack.pop() == "mark":
+                    break
+
+        def memo_key(arg: object) -> str:
+            return str(arg)
+
+        def callable_is_extension(offset_from_top: int) -> bool:
+            return len(stack) >= offset_from_top and stack[-offset_from_top] == "extension"
+
         try:
-            for opcode, _arg, _pos in pickletools.genops(candidate):
+            for opcode, arg, _pos in pickletools.genops(candidate):
                 if opcode.name in _PICKLE_EXTENSION_OPCODES:
-                    extension_seen = True
+                    push("extension")
+                    continue
+                if opcode.name == "MARK":
+                    push("mark")
                     continue
                 if opcode.name == "STOP":
                     return False
-                if extension_seen and opcode.name in _PICKLE_EXTENSION_EXECUTION_OPCODES:
-                    return True
-                if opcode.name in {"POP", "POP_MARK"}:
-                    extension_seen = False
+                if opcode.name == "POP":
+                    pop()
+                    continue
+                if opcode.name == "POP_MARK":
+                    pop_until_mark()
+                    continue
+                if opcode.name in {"BINPUT", "LONG_BINPUT", "PUT"}:
+                    if stack:
+                        memo[memo_key(arg)] = stack[-1]
+                    continue
+                if opcode.name == "MEMOIZE":
+                    if stack:
+                        memo[str(len(memo))] = stack[-1]
+                    continue
+                if opcode.name in {"BINGET", "LONG_BINGET", "GET"}:
+                    push(memo.get(memo_key(arg), "other"))
+                    continue
+                if opcode.name == "DUP":
+                    push(stack[-1] if stack else "other")
+                    continue
+                if opcode.name == "TUPLE":
+                    pop_until_mark()
+                    push("other")
+                    continue
+                if opcode.name in {"LIST", "DICT", "FROZENSET"}:
+                    pop_until_mark()
+                    push("other")
+                    continue
+                if opcode.name in {"APPENDS", "SETITEMS", "ADDITEMS"}:
+                    pop_until_mark()
+                    continue
+                if opcode.name == "EMPTY_TUPLE":
+                    push("other")
+                    continue
+                if opcode.name in {"TUPLE1", "TUPLE2", "TUPLE3"}:
+                    for _ in range(int(opcode.name[-1])):
+                        pop()
+                    push("other")
+                    continue
+                if opcode.name == "REDUCE":
+                    if callable_is_extension(2):
+                        return True
+                    pop()
+                    pop()
+                    push("other")
+                    continue
+                if opcode.name == "NEWOBJ":
+                    if callable_is_extension(2):
+                        return True
+                    pop()
+                    pop()
+                    push("other")
+                    continue
+                if opcode.name == "NEWOBJ_EX":
+                    if callable_is_extension(3):
+                        return True
+                    pop()
+                    pop()
+                    pop()
+                    push("other")
+                    continue
+                if opcode.name == "OBJ":
+                    try:
+                        mark_index = len(stack) - 1 - stack[::-1].index("mark")
+                    except ValueError:
+                        mark_index = -1
+                    if mark_index >= 0 and mark_index + 1 < len(stack) and stack[mark_index + 1] == "extension":
+                        return True
+                    pop_until_mark()
+                    push("other")
+                    continue
+                if opcode.name == "BUILD":
+                    if callable_is_extension(2):
+                        return True
+                    pop()
+                    pop()
+                    push("other")
+                    continue
+                if opcode.stack_before:
+                    for _ in opcode.stack_before:
+                        pop()
+                if opcode.stack_after:
+                    for _ in opcode.stack_after:
+                        push("other")
         except Exception:
             return False
         return False
@@ -3329,8 +3431,15 @@ class PyTorchZipScanner(BaseScanner):
                 return PyTorchZipScanner._raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(
                     value[offset:]
                 )
-            candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-            candidate_is_prefix = offset + len(candidate) < len(value)
+            candidate_start = (
+                offset - 1
+                if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+                and offset > 0
+                and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE
+                else offset
+            )
+            candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+            candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if marker == 0x80 and PyTorchZipScanner._looks_like_binary_pickle_prefix(
                 candidate, sample_is_prefix=candidate_is_prefix
             ):
@@ -3603,8 +3712,9 @@ class PyTorchZipScanner(BaseScanner):
                 return False
             if not PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining):
                 return True
-            candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-            candidate_is_prefix = offset + len(candidate) < len(value)
+            candidate_start = offset - 1 if offset > 0 and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE else offset
+            candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+            candidate_is_prefix = candidate_start + len(candidate) < len(value)
             if PyTorchZipScanner._has_executable_extension_opcode_before_stop(candidate):
                 return True
             if PyTorchZipScanner._raw_nested_binary_candidate_should_scan(

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -1543,7 +1543,11 @@ def _trusted_storage_zip_entry_looks_like_pickle(
     ):
         return False
     if max_probe_bytes > _TRUSTED_STORAGE_PICKLE_PROBE_BYTES:
-        if _has_complete_pickle_stream_without_frame_stop_overrun(prefix):
+        if _has_complete_pickle_stream_without_frame_stop_overrun(prefix) and not (
+            is_headerless_binary_pickle_candidate
+            and entry.file_size > len(prefix)
+            and _complete_headerless_byte_literal_prefix_has_only_padding(prefix)
+        ):
             return True
         try:
             for _opcode, _arg, _position in pickletools.genops(prefix):
@@ -1600,12 +1604,25 @@ def _trusted_storage_zip_entry_looks_like_pickle(
         )
     if is_headerless_binary_pickle_candidate:
         short_sample = sample[:_TRUSTED_STORAGE_PICKLE_PROBE_BYTES]
-        should_scan = _raw_nested_binary_candidate_should_scan(
-            sample,
-            candidate_is_prefix=entry.file_size > len(sample),
-        ) or _raw_nested_binary_candidate_should_scan(
-            short_sample,
-            candidate_is_prefix=entry.file_size > len(short_sample),
+        should_scan = (
+            _raw_nested_binary_candidate_should_scan(
+                sample,
+                candidate_is_prefix=entry.file_size > len(sample),
+            )
+            or _raw_nested_binary_candidate_should_scan(
+                short_sample,
+                candidate_is_prefix=entry.file_size > len(short_sample),
+            )
+            or _raw_nested_extension_opcode_candidate_has_structural_signal(
+                sample,
+                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                fail_closed_on_unknown_after_extension=True,
+            )
+            or _raw_nested_extension_opcode_candidate_has_structural_signal(
+                short_sample,
+                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                fail_closed_on_unknown_after_extension=True,
+            )
         )
         if should_scan:
             return True
@@ -1616,6 +1633,12 @@ def _trusted_storage_zip_entry_looks_like_pickle(
             and _complete_headerless_byte_literal_prefix_has_only_padding(sample)
         ):
             defer_padding_probe[0] = True
+        if (
+            max_probe_bytes > _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
+            and entry.file_size > len(sample)
+            and _complete_headerless_byte_literal_prefix_has_only_padding(sample)
+        ):
+            raise ValueError("trusted PyTorch storage padding probe limit reached")
         return False
     if is_frame_first_candidate:
         if _frame_first_trusted_storage_probe_should_scan(sample) or (
@@ -2088,6 +2111,7 @@ def _has_executable_extension_opcode_before_stop(
     candidate: bytes,
     *,
     fail_closed_on_truncated_extension: bool = True,
+    fail_closed_on_unknown_after_extension: bool = False,
 ) -> bool:
     stack: list[str] = []
     memo: dict[str, str] = {}
@@ -2233,7 +2257,7 @@ def _has_executable_extension_opcode_before_stop(
             return False
         message = str(error)
         if "opcode" in message and "unknown" in message:
-            return parsed_after_extension
+            return parsed_after_extension or fail_closed_on_unknown_after_extension
         if "pickle exhausted before seeing STOP" in message:
             return fail_closed_on_truncated_extension
         return True
@@ -2806,10 +2830,7 @@ def _literal_value_has_raw_nested_security_pickle(
                 extension_parse_budget_remaining,
             )
             if exhausted_budget:
-                candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-                if _extension_candidate_after_exhausted_context_should_scan(candidate):
-                    return True
-                continue
+                return True
             candidate_start = recovered_start
             recovered_extension_context = True
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
@@ -2895,10 +2916,7 @@ def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: byt
         return True
     if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
         return True
-    return _raw_nested_security_pickle_candidate_has_structural_signal(
-        value,
-        fail_closed_on_truncated_extension=False,
-    )
+    return _raw_nested_security_pickle_candidate_has_structural_signal(value)
 
 
 def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
@@ -3055,6 +3073,7 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
     parse_budget_remaining: list[int],
     *,
     fail_closed_on_truncated_extension: bool = True,
+    fail_closed_on_unknown_after_extension: bool = False,
 ) -> bool:
     search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
     search_start = 0
@@ -3075,16 +3094,13 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             parse_budget_remaining,
         )
         if exhausted_budget:
-            candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-            if _extension_candidate_after_exhausted_context_should_scan(candidate):
-                return True
-            search_start = offset + 1
-            continue
+            return True
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if _has_executable_extension_opcode_before_stop(
             candidate,
             fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
+            fail_closed_on_unknown_after_extension=fail_closed_on_unknown_after_extension,
         ):
             return True
         if _raw_nested_binary_candidate_should_scan(candidate, candidate_is_prefix=candidate_is_prefix):
@@ -3111,7 +3127,7 @@ def _raw_nested_extension_candidate_start(
             search_start += 1
         candidate_start, stop_pos, exhausted_budget = parse_candidate(search_start)
         if exhausted_budget:
-            return offset, True
+            return search_start, True
         if candidate_start is not None:
             return candidate_start, False
         if stop_pos is None or stop_pos < search_start:
@@ -3122,7 +3138,7 @@ def _raw_nested_extension_candidate_start(
     while mark >= window_start:
         candidate_start, _stop_pos, exhausted_budget = parse_candidate(mark)
         if exhausted_budget:
-            return offset, True
+            return mark, True
         if candidate_start is not None:
             return candidate_start, False
         mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, mark)
@@ -3278,7 +3294,7 @@ def _headerless_binary_byte_literal_has_possible_size(candidate: bytes, *, entry
         literal_size = int.from_bytes(candidate[1:5], "little")
     else:
         literal_size = int.from_bytes(candidate[1:9], "little")
-    return header_bytes + literal_size + 1 <= entry_size
+    return header_bytes + literal_size <= entry_size
 
 
 def _headerless_binary_pickle_prefix_needs_more_bytes(candidate: bytes, *, candidate_is_prefix: bool) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -161,6 +161,7 @@ _BINARY_EXTENSION_SECURITY_OPCODE_BYTES = b"\x82\x83\x84"
 _BINARY_SECURITY_OPCODE_REQUIRING_EXISTING_STACK_BYTES = b"\x81\x92\x93"
 _MAX_RAW_NESTED_PICKLE_CANDIDATES = 64
 _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES = 8 * 1024
+_MAX_NESTED_LITERAL_SCAN_DEPTH = 8
 _RAW_NESTED_SECURITY_PICKLE_TEXT_MARKERS = (
     b"builtins\neval\n",
     b"builtins\nexec\n",
@@ -1530,6 +1531,7 @@ def _trusted_storage_zip_entry_looks_like_pickle(
         not is_binary_pickle_candidate
         and not is_frame_first_candidate
         and prefix[0] in _HEADERLESS_BINARY_PICKLE_START_BYTES
+        and _headerless_binary_byte_literal_has_possible_size(prefix, entry_size=entry.file_size)
     )
     if (
         not is_binary_pickle_candidate
@@ -1569,7 +1571,10 @@ def _trusted_storage_zip_entry_looks_like_pickle(
         if (
             max_probe_bytes > _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
             and entry.file_size > max_probe_bytes
-            and _trivial_complete_pickle_prefix_has_only_padding(prefix)
+            and (
+                _trivial_complete_pickle_prefix_has_only_padding(prefix)
+                or _complete_headerless_byte_literal_prefix_has_only_padding(prefix)
+            )
             and defer_padding_probe is None
         ):
             padding_probe_bytes = min(entry.file_size, _PICKLE_DISCOVERY_PADDING_PROBE_BYTES)
@@ -1593,13 +1598,23 @@ def _trusted_storage_zip_entry_looks_like_pickle(
         )
     if is_headerless_binary_pickle_candidate:
         short_sample = sample[:_TRUSTED_STORAGE_PICKLE_PROBE_BYTES]
-        return _raw_nested_binary_candidate_should_scan(
+        should_scan = _raw_nested_binary_candidate_should_scan(
             sample,
             candidate_is_prefix=entry.file_size > len(sample),
         ) or _raw_nested_binary_candidate_should_scan(
             short_sample,
             candidate_is_prefix=entry.file_size > len(short_sample),
         )
+        if should_scan:
+            return True
+        if (
+            max_probe_bytes == _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
+            and defer_padding_probe is not None
+            and entry.file_size > len(sample)
+            and _complete_headerless_byte_literal_prefix_has_only_padding(sample)
+        ):
+            defer_padding_probe[0] = True
+        return False
     if is_frame_first_candidate:
         if _frame_first_trusted_storage_probe_should_scan(sample) or (
             max_probe_bytes > _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
@@ -1941,7 +1956,14 @@ def _has_security_relevant_pickle_opcode(sample: bytes) -> bool:
     return False
 
 
-def _trailing_pickle_probe_should_scan(trailing: bytes, *, sample_is_prefix: bool) -> bool:
+def _trailing_pickle_probe_should_scan(
+    trailing: bytes,
+    *,
+    sample_is_prefix: bool,
+    nested_literal_depth: int = 0,
+) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     candidate = trailing.lstrip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
     if not candidate:
         return False
@@ -1960,7 +1982,11 @@ def _trailing_pickle_probe_should_scan(trailing: bytes, *, sample_is_prefix: boo
         )
     ):
         return True
-    if _trailing_candidate_has_raw_nested_security_pickle(candidate, sample_is_prefix=sample_is_prefix):
+    if _trailing_candidate_has_raw_nested_security_pickle(
+        candidate,
+        sample_is_prefix=sample_is_prefix,
+        nested_literal_depth=nested_literal_depth,
+    ):
         return True
     if _malformed_separator_proto0_literal_has_nested_security_pickle(candidate):
         return True
@@ -2056,9 +2082,18 @@ def _looks_like_truncated_security_opcode_prefix(candidate: bytes) -> bool:
     return False
 
 
-def _trivial_complete_pickle_prefix_trailing_should_scan(sample: bytes, *, sample_is_prefix: bool) -> bool:
+def _trivial_complete_pickle_prefix_trailing_should_scan(
+    sample: bytes,
+    *,
+    sample_is_prefix: bool,
+    nested_literal_depth: int = 0,
+) -> bool:
     trailing = _trivial_complete_pickle_prefix_trailing(sample)
-    return trailing is not None and _trailing_pickle_probe_should_scan(trailing, sample_is_prefix=sample_is_prefix)
+    return trailing is not None and _trailing_pickle_probe_should_scan(
+        trailing,
+        sample_is_prefix=sample_is_prefix,
+        nested_literal_depth=nested_literal_depth,
+    )
 
 
 def _trivial_complete_pickle_prefix_has_ambiguous_trivial_trailing(sample: bytes) -> bool:
@@ -2168,6 +2203,11 @@ def _trivial_complete_pickle_prefix_has_only_padding(sample: bytes) -> bool:
     return trailing is not None and not trailing.strip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
 
 
+def _complete_headerless_byte_literal_prefix_has_only_padding(sample: bytes) -> bool:
+    trailing = _complete_headerless_byte_literal_prefix_trailing(sample)
+    return trailing is not None and not trailing.strip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
+
+
 def _trivial_complete_pickle_prefix_has_only_nul_padding(sample: bytes) -> bool:
     trailing = _trivial_complete_pickle_prefix_trailing(sample)
     return trailing is not None and bool(trailing) and not trailing.strip(b"\x00")
@@ -2233,7 +2273,36 @@ def _trivial_complete_pickle_prefix_trailing(sample: bytes) -> bytes | None:
     return None
 
 
-def _complete_trivial_literal_pickle_has_nested_security_pickle(sample: bytes) -> bool:
+def _complete_headerless_byte_literal_prefix_trailing(sample: bytes) -> bytes | None:
+    if not sample or sample[0] not in _PICKLE_BINARY_BYTE_LITERAL_START_BYTES:
+        return None
+    opcode_count = 0
+    try:
+        for opcode, _arg, pos in pickletools.genops(sample):
+            opcode_count += 1
+            if pos is None:
+                continue
+            if opcode_count == 1:
+                if opcode.name not in _PICKLE_BINARY_BYTE_LITERAL_OPCODES:
+                    return None
+            elif opcode.name == "STOP":
+                if opcode_count != 2:
+                    return None
+                return sample[pos + 1 :]
+            else:
+                return None
+    except Exception:
+        return None
+    return None
+
+
+def _complete_trivial_literal_pickle_has_nested_security_pickle(
+    sample: bytes,
+    *,
+    nested_literal_depth: int = 0,
+) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     cursor = 0
     stream = io.BytesIO(sample)
     while cursor < len(sample):
@@ -2260,7 +2329,13 @@ def _complete_trivial_literal_pickle_has_nested_security_pickle(sample: bytes) -
                 elif opcode.name == "STOP":
                     if opcode_count < 2 or active_frame_end > len(sample):
                         return False
-                    if any(_literal_value_has_storage_scan_signal(value) for value in literal_values):
+                    if any(
+                        _literal_value_has_storage_scan_signal(
+                            value,
+                            nested_literal_depth=nested_literal_depth + 1,
+                        )
+                        for value in literal_values
+                    ):
                         return True
                     cursor = pos + 1
                     while cursor < len(sample) and sample[cursor] in _PROTO0_1_IGNORABLE_TRAILING_BYTES:
@@ -2275,11 +2350,20 @@ def _complete_trivial_literal_pickle_has_nested_security_pickle(sample: bytes) -
             else:
                 return False
         except Exception:
-            return _complete_proto0_string_literal_has_nested_security_pickle(sample[cursor:])
+            return _complete_proto0_string_literal_has_nested_security_pickle(
+                sample[cursor:],
+                nested_literal_depth=nested_literal_depth,
+            )
     return False
 
 
-def _complete_proto0_string_literal_has_nested_security_pickle(sample: bytes) -> bool:
+def _complete_proto0_string_literal_has_nested_security_pickle(
+    sample: bytes,
+    *,
+    nested_literal_depth: int = 0,
+) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     if not sample.startswith(b"S"):
         return False
     line_end = sample.find(b"\n", 1)
@@ -2299,7 +2383,10 @@ def _complete_proto0_string_literal_has_nested_security_pickle(sample: bytes) ->
     literal_value = (
         decoded_literal if isinstance(decoded_literal, bytes) else _literal_str_to_scan_bytes(decoded_literal)
     )
-    return _literal_value_has_storage_scan_signal(literal_value)
+    return _literal_value_has_storage_scan_signal(
+        literal_value,
+        nested_literal_depth=nested_literal_depth + 1,
+    )
 
 
 def _literal_arg_bytes(opcode_name: str, value: Any) -> bytes | None:
@@ -2329,14 +2416,23 @@ def _literal_str_to_scan_bytes(value: str) -> bytes:
     return bytes(output)
 
 
-def _literal_value_has_nested_security_pickle(value: bytes) -> bool:
-    return _literal_value_has_raw_nested_security_pickle(value) or _literal_value_has_encoded_nested_security_pickle(
-        value
+def _literal_value_has_nested_security_pickle(value: bytes, *, nested_literal_depth: int = 0) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
+    return _literal_value_has_raw_nested_security_pickle(
+        value,
+        nested_literal_depth=nested_literal_depth,
+    ) or _literal_value_has_encoded_nested_security_pickle(
+        value,
+        nested_literal_depth=nested_literal_depth,
     )
 
 
-def _literal_value_has_storage_scan_signal(value: bytes) -> bool:
-    return _literal_value_has_nested_security_pickle(value) or _literal_value_has_suspicious_text(value)
+def _literal_value_has_storage_scan_signal(value: bytes, *, nested_literal_depth: int = 0) -> bool:
+    return _literal_value_has_nested_security_pickle(
+        value,
+        nested_literal_depth=nested_literal_depth,
+    ) or _literal_value_has_suspicious_text(value)
 
 
 def _literal_value_has_suspicious_text(value: bytes) -> bool:
@@ -2514,8 +2610,13 @@ def _hex_literal_value_has_suspicious_text(value: bytes) -> bool:
 
 
 def _literal_value_has_raw_nested_security_pickle(
-    value: bytes, *, fail_closed_on_candidate_budget: bool = True
+    value: bytes,
+    *,
+    fail_closed_on_candidate_budget: bool = True,
+    nested_literal_depth: int = 0,
 ) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     candidate_count = 0
     for offset, marker in enumerate(value):
         if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
@@ -2536,6 +2637,7 @@ def _literal_value_has_raw_nested_security_pickle(
         if marker in _RAW_NESTED_BINARY_SECURITY_PICKLE_START_BYTES and _raw_nested_binary_candidate_should_scan(
             candidate,
             candidate_is_prefix=candidate_is_prefix,
+            nested_literal_depth=nested_literal_depth + 1,
         ):
             return True
         if (
@@ -2558,7 +2660,14 @@ def _literal_value_has_raw_nested_security_pickle(
     return False
 
 
-def _trailing_candidate_has_raw_nested_security_pickle(value: bytes, *, sample_is_prefix: bool) -> bool:
+def _trailing_candidate_has_raw_nested_security_pickle(
+    value: bytes,
+    *,
+    sample_is_prefix: bool,
+    nested_literal_depth: int = 0,
+) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     parse_attempt_count = 0
     for offset, marker in enumerate(value):
         if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
@@ -2575,6 +2684,7 @@ def _trailing_candidate_has_raw_nested_security_pickle(value: bytes, *, sample_i
         if marker in _RAW_NESTED_BINARY_SECURITY_PICKLE_START_BYTES and _raw_nested_binary_candidate_should_scan(
             candidate,
             candidate_is_prefix=candidate_is_prefix,
+            nested_literal_depth=nested_literal_depth + 1,
         ):
             return True
         if (
@@ -2787,10 +2897,26 @@ def _raw_nested_binary_opcode_candidate_has_structural_signal(value: bytes, pars
     return False
 
 
-def _raw_nested_binary_candidate_should_scan(candidate: bytes, *, candidate_is_prefix: bool) -> bool:
+def _raw_nested_binary_candidate_should_scan(
+    candidate: bytes,
+    *,
+    candidate_is_prefix: bool,
+    nested_literal_depth: int = 0,
+) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     if _headerless_binary_pickle_prefix_needs_more_bytes(candidate, candidate_is_prefix=candidate_is_prefix):
         return True
-    if _complete_trivial_literal_pickle_has_nested_security_pickle(candidate):
+    if _complete_trivial_literal_pickle_has_nested_security_pickle(
+        candidate,
+        nested_literal_depth=nested_literal_depth,
+    ):
+        return True
+    if _trivial_complete_pickle_prefix_trailing_should_scan(
+        candidate,
+        sample_is_prefix=candidate_is_prefix,
+        nested_literal_depth=nested_literal_depth + 1,
+    ):
         return True
     if not _has_security_relevant_pickle_opcode(candidate):
         return False
@@ -2799,6 +2925,29 @@ def _raw_nested_binary_candidate_should_scan(candidate: bytes, *, candidate_is_p
     if _frame_first_trusted_storage_probe_should_scan(candidate):
         return True
     return candidate_is_prefix and _has_security_relevant_opcode_in_incomplete_frame(candidate)
+
+
+def _headerless_binary_byte_literal_has_possible_size(candidate: bytes, *, entry_size: int) -> bool:
+    if not candidate or candidate[0] not in _PICKLE_BINARY_BYTE_LITERAL_START_BYTES:
+        return True
+    opcode = candidate[0]
+    if opcode == ord("C"):
+        header_bytes = 2
+    elif opcode == ord("B"):
+        header_bytes = 5
+    else:
+        header_bytes = 9
+    if entry_size < header_bytes + 1:
+        return False
+    if len(candidate) < header_bytes:
+        return True
+    if opcode == ord("C"):
+        literal_size = candidate[1]
+    elif opcode == ord("B"):
+        literal_size = int.from_bytes(candidate[1:5], "little")
+    else:
+        literal_size = int.from_bytes(candidate[1:9], "little")
+    return header_bytes + literal_size + 1 <= entry_size
 
 
 def _headerless_binary_pickle_prefix_needs_more_bytes(candidate: bytes, *, candidate_is_prefix: bool) -> bool:
@@ -2833,7 +2982,9 @@ def _raw_nested_security_pickle_text_marker_seen(value: bytes) -> bool:
     return any(marker in value for marker in _RAW_NESTED_SECURITY_PICKLE_TEXT_MARKERS)
 
 
-def _literal_value_has_encoded_nested_security_pickle(value: bytes) -> bool:
+def _literal_value_has_encoded_nested_security_pickle(value: bytes, *, nested_literal_depth: int = 0) -> bool:
+    if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
+        return True
     for match in _BASE64_NESTED_LITERAL_TOKEN_RE.finditer(value):
         token = _BASE64_NESTED_LITERAL_SEPARATOR_RE.sub(b"", match.group(0)).translate(bytes.maketrans(b"-_", b"+/"))
         token_segments = _base64_literal_route_token_segments(token)
@@ -2843,13 +2994,18 @@ def _literal_value_has_encoded_nested_security_pickle(value: bytes) -> bool:
             candidate_token = token[token_start:token_end]
             for shift in range(min(4, len(candidate_token))):
                 shifted_token = candidate_token[shift:]
+                shifted_token = shifted_token.rstrip(b"=")
+                if not shifted_token:
+                    continue
                 shifted_token += b"=" * (-len(shifted_token) % 4)
                 try:
                     decoded = base64.b64decode(shifted_token, validate=True)
                 except (binascii.Error, ValueError):
                     continue
                 if decoded and _literal_value_has_raw_nested_security_pickle(
-                    decoded, fail_closed_on_candidate_budget=False
+                    decoded,
+                    fail_closed_on_candidate_budget=False,
+                    nested_literal_depth=nested_literal_depth + 1,
                 ):
                     return True
     for match in _HEX_NESTED_LITERAL_TOKEN_RE.finditer(value):
@@ -2864,7 +3020,9 @@ def _literal_value_has_encoded_nested_security_pickle(value: bytes) -> bool:
             except (binascii.Error, ValueError):
                 continue
             if decoded and _literal_value_has_raw_nested_security_pickle(
-                decoded, fail_closed_on_candidate_budget=False
+                decoded,
+                fail_closed_on_candidate_budget=False,
+                nested_literal_depth=nested_literal_depth + 1,
             ):
                 return True
     return False

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2087,6 +2087,7 @@ def _looks_like_truncated_security_opcode_prefix(candidate: bytes) -> bool:
 def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
     stack: list[str] = []
     memo: dict[str, str] = {}
+    saw_extension_opcode = False
 
     def push(value: str) -> None:
         stack.append(value)
@@ -2118,6 +2119,7 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
     try:
         for opcode, arg, _pos in pickletools.genops(candidate):
             if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                saw_extension_opcode = True
                 push("extension")
                 continue
             if opcode.name == "MARK":
@@ -2220,7 +2222,7 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
                 for _ in opcode.stack_after:
                     push("other")
     except Exception:
-        return False
+        return saw_extension_opcode
     return False
 
 
@@ -3013,9 +3015,13 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
         )
         if offset < 0:
             return False
-        if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+        candidate_start, exhausted_budget = _raw_nested_extension_candidate_start(
+            value,
+            offset,
+            parse_budget_remaining,
+        )
+        if exhausted_budget:
             return True
-        candidate_start = _raw_nested_extension_candidate_start(value, offset)
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if _has_executable_extension_opcode_before_stop(candidate):
@@ -3026,12 +3032,67 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
     return False
 
 
-def _raw_nested_extension_candidate_start(value: bytes, offset: int) -> int:
+def _raw_nested_extension_candidate_start(
+    value: bytes,
+    offset: int,
+    parse_budget_remaining: list[int],
+) -> tuple[int, bool]:
+    def parse_candidate(start: int) -> tuple[int | None, int | None, bool]:
+        if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+            return None, None, True
+        candidate_start, stop_pos = _parsed_raw_nested_extension_candidate_start(value, start, offset)
+        return candidate_start, stop_pos, False
+
     window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
-    stop = value.rfind(b".", window_start, offset)
-    mark_search_start = stop + 1 if stop >= 0 else window_start
-    mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), mark_search_start, offset)
-    return mark if mark >= 0 else offset
+    search_start = window_start
+    while search_start <= offset:
+        while search_start < offset and value[search_start] in _PROTO0_1_IGNORABLE_TRAILING_BYTES:
+            search_start += 1
+        candidate_start, stop_pos, exhausted_budget = parse_candidate(search_start)
+        if exhausted_budget:
+            return offset, True
+        if candidate_start is not None:
+            return candidate_start, False
+        if stop_pos is None or stop_pos < search_start:
+            break
+        search_start = stop_pos + 1
+
+    mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, offset)
+    while mark >= window_start:
+        candidate_start, _stop_pos, exhausted_budget = parse_candidate(mark)
+        if exhausted_budget:
+            return offset, True
+        if candidate_start is not None:
+            return candidate_start, False
+        mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), window_start, mark)
+    return offset, False
+
+
+def _parsed_raw_nested_extension_candidate_start(
+    value: bytes,
+    start: int,
+    offset: int,
+) -> tuple[int | None, int | None]:
+    parse_end = min(len(value), offset + 5)
+    live_mark: int | None = None
+    try:
+        for opcode, _arg, pos in pickletools.genops(value[start:parse_end]):
+            if pos is None:
+                continue
+            absolute_pos = start + pos
+            if absolute_pos == offset:
+                if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                    return (live_mark if live_mark is not None else offset), None
+                return None, None
+            if absolute_pos > offset:
+                return start, None
+            if opcode.name == "STOP":
+                return None, absolute_pos
+            if opcode.name == "MARK":
+                live_mark = absolute_pos
+    except Exception:
+        return None, None
+    return None, None
 
 
 def _raw_nested_binary_opcode_candidate_has_structural_signal(value: bytes, parse_budget_remaining: list[int]) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -158,8 +158,6 @@ _RAW_NESTED_SECURITY_PICKLE_START_BYTES = (
     _RAW_NESTED_TEXT_SECURITY_PICKLE_START_BYTES + _RAW_NESTED_BINARY_SECURITY_PICKLE_START_BYTES
 )
 _BINARY_EXTENSION_SECURITY_OPCODE_BYTES = b"\x82\x83\x84"
-_BINARY_EXTENSION_OPCODE_OPERAND_BYTES = {0x82: 1, 0x83: 2, 0x84: 4}
-_BINARY_EXTENSION_OPCODE_FOLLOWER_BYTES = b".)Rq\x85\x86\x87\x94\x95"
 _BINARY_SECURITY_OPCODE_REQUIRING_EXISTING_STACK_BYTES = b"\x81\x92\x93"
 _MAX_RAW_NESTED_PICKLE_CANDIDATES = 64
 _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES = 8 * 1024
@@ -2542,7 +2540,10 @@ def _literal_value_has_raw_nested_security_pickle(
             return True
         if (
             marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-            and _raw_nested_extension_opcode_candidate_has_structural_signal(candidate)
+            and _raw_nested_extension_opcode_candidate_has_structural_signal(
+                candidate,
+                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+            )
         ):
             return True
         if (
@@ -2631,7 +2632,7 @@ def _raw_nested_security_pickle_candidate_has_structural_signal(value: bytes) ->
         return True
     if _raw_nested_binary_protocol_candidate_has_structural_signal(value, parse_budget_remaining):
         return True
-    if _raw_nested_extension_opcode_candidate_has_structural_signal(value):
+    if _raw_nested_extension_opcode_candidate_has_structural_signal(value, parse_budget_remaining):
         return True
     if _raw_nested_binary_opcode_candidate_has_structural_signal(value, parse_budget_remaining):
         return True
@@ -2735,7 +2736,10 @@ def _raw_nested_binary_protocol_candidate_has_structural_signal(
     return False
 
 
-def _raw_nested_extension_opcode_candidate_has_structural_signal(value: bytes) -> bool:
+def _raw_nested_extension_opcode_candidate_has_structural_signal(
+    value: bytes,
+    parse_budget_remaining: list[int],
+) -> bool:
     search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
     search_start = 0
     while search_start < search_limit:
@@ -2749,13 +2753,11 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(value: bytes) -
         )
         if offset < 0:
             return False
-        operand_len = _BINARY_EXTENSION_OPCODE_OPERAND_BYTES[value[offset]]
-        follower_offset = offset + 1 + operand_len
-        if (
-            follower_offset < search_limit
-            and follower_offset < len(value)
-            and value[follower_offset] in _BINARY_EXTENSION_OPCODE_FOLLOWER_BYTES
-        ):
+        if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
+            return True
+        candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+        candidate_is_prefix = offset + len(candidate) < len(value)
+        if _raw_nested_binary_candidate_should_scan(candidate, candidate_is_prefix=candidate_is_prefix):
             return True
         search_start = offset + 1
     return False

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2084,10 +2084,15 @@ def _looks_like_truncated_security_opcode_prefix(candidate: bytes) -> bool:
     return False
 
 
-def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
+def _has_executable_extension_opcode_before_stop(
+    candidate: bytes,
+    *,
+    fail_closed_on_truncated_extension: bool = True,
+) -> bool:
     stack: list[str] = []
     memo: dict[str, str] = {}
     saw_extension_opcode = False
+    parsed_after_extension = False
 
     def push(value: str) -> None:
         stack.append(value)
@@ -2122,6 +2127,8 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
                 saw_extension_opcode = True
                 push("extension")
                 continue
+            if saw_extension_opcode:
+                parsed_after_extension = True
             if opcode.name == "MARK":
                 push("mark")
                 continue
@@ -2221,8 +2228,15 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
             if opcode.stack_after:
                 for _ in opcode.stack_after:
                     push("other")
-    except Exception:
-        return saw_extension_opcode
+    except Exception as error:
+        if not saw_extension_opcode:
+            return False
+        message = str(error)
+        if "opcode" in message and "unknown" in message:
+            return parsed_after_extension
+        if "pickle exhausted before seeing STOP" in message:
+            return fail_closed_on_truncated_extension
+        return True
     return False
 
 
@@ -2771,13 +2785,33 @@ def _literal_value_has_raw_nested_security_pickle(
             if not fail_closed_on_candidate_budget:
                 return _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value[offset:])
             return _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value[offset:])
-        candidate_start = (
-            offset - 1
-            if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-            and offset > 0
-            and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE
-            else offset
-        )
+        candidate_start = offset
+        recovered_extension_context = False
+        if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+            extension_window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
+            recover_extension_context = (
+                value.rfind(
+                    bytes([_PICKLE_MARK_OPCODE_BYTE]),
+                    extension_window_start,
+                    offset,
+                )
+                >= extension_window_start
+            )
+        else:
+            recover_extension_context = False
+        if recover_extension_context:
+            recovered_start, exhausted_budget = _raw_nested_extension_candidate_start(
+                value,
+                offset,
+                extension_parse_budget_remaining,
+            )
+            if exhausted_budget:
+                candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+                if _extension_candidate_after_exhausted_context_should_scan(candidate):
+                    return True
+                continue
+            candidate_start = recovered_start
+            recovered_extension_context = True
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if marker == 0x80 and _looks_like_binary_pickle_prefix(candidate, sample_is_prefix=candidate_is_prefix):
@@ -2792,14 +2826,19 @@ def _literal_value_has_raw_nested_security_pickle(
             nested_literal_depth=nested_literal_depth + 1,
         ):
             return True
-        if (
-            marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
-            and _raw_nested_extension_opcode_candidate_has_structural_signal(
+        if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+            if recovered_extension_context:
+                if _has_executable_extension_opcode_before_stop(candidate) or _raw_nested_binary_candidate_should_scan(
+                    candidate,
+                    candidate_is_prefix=candidate_is_prefix,
+                    nested_literal_depth=nested_literal_depth + 1,
+                ):
+                    return True
+            elif _raw_nested_extension_opcode_candidate_has_structural_signal(
                 candidate,
                 extension_parse_budget_remaining,
-            )
-        ):
-            return True
+            ):
+                return True
         if (
             marker in _PROTO0_1_START_BYTES
             and _has_security_relevant_pickle_opcode(candidate)
@@ -2854,7 +2893,12 @@ def _trailing_candidate_has_raw_nested_security_pickle(
 def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
     if _raw_nested_security_pickle_text_marker_seen(value):
         return True
-    return _raw_nested_security_pickle_candidate_has_structural_signal(value)
+    if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
+        return True
+    return _raw_nested_security_pickle_candidate_has_structural_signal(
+        value,
+        fail_closed_on_truncated_extension=False,
+    )
 
 
 def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
@@ -2888,13 +2932,21 @@ def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(va
     return _raw_nested_security_pickle_candidate_has_structural_signal(value)
 
 
-def _raw_nested_security_pickle_candidate_has_structural_signal(value: bytes) -> bool:
+def _raw_nested_security_pickle_candidate_has_structural_signal(
+    value: bytes,
+    *,
+    fail_closed_on_truncated_extension: bool = True,
+) -> bool:
     parse_budget_remaining = [_MAX_RAW_NESTED_PICKLE_CANDIDATES]
     if _raw_nested_proto0_global_ref_seen(value):
         return True
     if _raw_nested_binary_protocol_candidate_has_structural_signal(value, parse_budget_remaining):
         return True
-    if _raw_nested_extension_opcode_candidate_has_structural_signal(value, parse_budget_remaining):
+    if _raw_nested_extension_opcode_candidate_has_structural_signal(
+        value,
+        parse_budget_remaining,
+        fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
+    ):
         return True
     if _raw_nested_binary_opcode_candidate_has_structural_signal(value, parse_budget_remaining):
         return True
@@ -2905,7 +2957,7 @@ def _raw_nested_security_pickle_candidate_has_structural_signal(value: bytes) ->
         return False
     marker = candidate[0]
     if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
-        return True
+        return fail_closed_on_truncated_extension or _has_complete_extension_opcode_stream(candidate)
     if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
         return True
     if marker == 0x80 and _looks_like_binary_pickle_prefix(candidate, sample_is_prefix=candidate_is_prefix):
@@ -3001,6 +3053,8 @@ def _raw_nested_binary_protocol_candidate_has_structural_signal(
 def _raw_nested_extension_opcode_candidate_has_structural_signal(
     value: bytes,
     parse_budget_remaining: list[int],
+    *,
+    fail_closed_on_truncated_extension: bool = True,
 ) -> bool:
     search_limit = min(len(value), _PICKLE_DISCOVERY_LONG_PROBE_BYTES)
     search_start = 0
@@ -3021,10 +3075,17 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             parse_budget_remaining,
         )
         if exhausted_budget:
-            return True
+            candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+            if _extension_candidate_after_exhausted_context_should_scan(candidate):
+                return True
+            search_start = offset + 1
+            continue
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = candidate_start + len(candidate) < len(value)
-        if _has_executable_extension_opcode_before_stop(candidate):
+        if _has_executable_extension_opcode_before_stop(
+            candidate,
+            fail_closed_on_truncated_extension=fail_closed_on_truncated_extension,
+        ):
             return True
         if _raw_nested_binary_candidate_should_scan(candidate, candidate_is_prefix=candidate_is_prefix):
             return True
@@ -3068,13 +3129,47 @@ def _raw_nested_extension_candidate_start(
     return offset, False
 
 
+def _has_complete_extension_opcode_stream(candidate: bytes) -> bool:
+    saw_extension_opcode = False
+    try:
+        for opcode, _arg, _pos in pickletools.genops(candidate):
+            if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                saw_extension_opcode = True
+                continue
+            if opcode.name == "STOP":
+                return saw_extension_opcode
+    except Exception:
+        return False
+    return False
+
+
+def _extension_candidate_after_exhausted_context_should_scan(candidate: bytes) -> bool:
+    return _has_complete_extension_opcode_stream(candidate) or _has_executable_extension_opcode_before_stop(
+        candidate,
+        fail_closed_on_truncated_extension=False,
+    )
+
+
 def _parsed_raw_nested_extension_candidate_start(
     value: bytes,
     start: int,
     offset: int,
 ) -> tuple[int | None, int | None]:
     parse_end = min(len(value), offset + 5)
-    live_mark: int | None = None
+    stack: list[int | None] = []
+
+    def pop_stack() -> None:
+        if stack:
+            stack.pop()
+
+    def pop_until_mark() -> None:
+        while stack:
+            if stack.pop() is not None:
+                break
+
+    def live_mark() -> int | None:
+        return next((item for item in reversed(stack) if item is not None), None)
+
     try:
         for opcode, _arg, pos in pickletools.genops(value[start:parse_end]):
             if pos is None:
@@ -3082,14 +3177,28 @@ def _parsed_raw_nested_extension_candidate_start(
             absolute_pos = start + pos
             if absolute_pos == offset:
                 if opcode.name in _PICKLE_EXTENSION_OPCODES:
-                    return (live_mark if live_mark is not None else offset), None
+                    mark = live_mark()
+                    return (mark if mark is not None else offset), None
                 return None, None
             if absolute_pos > offset:
                 return start, None
             if opcode.name == "STOP":
                 return None, absolute_pos
             if opcode.name == "MARK":
-                live_mark = absolute_pos
+                stack.append(absolute_pos)
+                continue
+            if opcode.name == "POP":
+                pop_stack()
+                continue
+            if opcode.name == "POP_MARK":
+                pop_until_mark()
+                continue
+            if opcode.stack_before:
+                for _ in opcode.stack_before:
+                    pop_stack()
+            if opcode.stack_after:
+                for _ in opcode.stack_after:
+                    stack.append(None)
     except Exception:
         return None, None
     return None, None

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2105,6 +2105,16 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
     def callable_is_extension(offset_from_top: int) -> bool:
         return len(stack) >= offset_from_top and stack[-offset_from_top] == "extension"
 
+    def last_mark_index() -> int:
+        try:
+            return len(stack) - 1 - stack[::-1].index("mark")
+        except ValueError:
+            return -1
+
+    def mark_target_is_extension() -> bool:
+        mark_index = last_mark_index()
+        return mark_index > 0 and stack[mark_index - 1] == "extension"
+
     try:
         for opcode, arg, _pos in pickletools.genops(candidate):
             if opcode.name in _PICKLE_EXTENSION_OPCODES:
@@ -2144,7 +2154,20 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
                 push("other")
                 continue
             if opcode.name in {"APPENDS", "SETITEMS", "ADDITEMS"}:
+                if mark_target_is_extension():
+                    return True
                 pop_until_mark()
+                continue
+            if opcode.name == "APPEND":
+                if callable_is_extension(2):
+                    return True
+                pop()
+                continue
+            if opcode.name == "SETITEM":
+                if callable_is_extension(3):
+                    return True
+                pop()
+                pop()
                 continue
             if opcode.name == "EMPTY_TUPLE":
                 push("other")
@@ -2177,10 +2200,7 @@ def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
                 push("other")
                 continue
             if opcode.name == "OBJ":
-                try:
-                    mark_index = len(stack) - 1 - stack[::-1].index("mark")
-                except ValueError:
-                    mark_index = -1
+                mark_index = last_mark_index()
                 if mark_index >= 0 and mark_index + 1 < len(stack) and stack[mark_index + 1] == "extension":
                     return True
                 pop_until_mark()
@@ -2740,6 +2760,7 @@ def _literal_value_has_raw_nested_security_pickle(
     if nested_literal_depth > _MAX_NESTED_LITERAL_SCAN_DEPTH:
         return True
     candidate_count = 0
+    extension_parse_budget_remaining = [_MAX_RAW_NESTED_PICKLE_CANDIDATES]
     for offset, marker in enumerate(value):
         if marker not in _RAW_NESTED_SECURITY_PICKLE_START_BYTES:
             continue
@@ -2773,7 +2794,7 @@ def _literal_value_has_raw_nested_security_pickle(
             marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
             and _raw_nested_extension_opcode_candidate_has_structural_signal(
                 candidate,
-                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+                extension_parse_budget_remaining,
             )
         ):
             return True
@@ -2994,7 +3015,7 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             return False
         if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
             return True
-        candidate_start = offset - 1 if offset > 0 and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE else offset
+        candidate_start = _raw_nested_extension_candidate_start(value, offset)
         candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if _has_executable_extension_opcode_before_stop(candidate):
@@ -3003,6 +3024,14 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             return True
         search_start = offset + 1
     return False
+
+
+def _raw_nested_extension_candidate_start(value: bytes, offset: int) -> int:
+    window_start = max(0, offset - _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES + 1)
+    stop = value.rfind(b".", window_start, offset)
+    mark_search_start = stop + 1 if stop >= 0 else window_start
+    mark = value.rfind(bytes([_PICKLE_MARK_OPCODE_BYTE]), mark_search_start, offset)
+    return mark if mark >= 0 else offset
 
 
 def _raw_nested_binary_opcode_candidate_has_structural_signal(value: bytes, parse_budget_remaining: list[int]) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2921,6 +2921,8 @@ def _trailing_candidate_has_raw_nested_security_pickle(
 
 
 def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
+    if _raw_nested_security_pickle_text_marker_seen(value):
+        return True
     if _budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value):
         return False
     return _raw_nested_security_pickle_candidate_has_structural_signal(value)
@@ -2948,6 +2950,8 @@ def _budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value
     if offset + len(candidate) < len(value):
         return False
     operand_len = {0x82: 1, 0x83: 2, 0x84: 4}[candidate[0]]
+    if len(candidate) >= 1 + operand_len:
+        return False
     trailing = candidate[1 + operand_len :]
     return not trailing or not trailing.strip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
 
@@ -6982,6 +6986,13 @@ def _with_unanalyzed_call_graph_notices(
     report: PickleReport,
     references: tuple[UnanalyzedCallGraphReference, ...],
 ) -> PickleReport:
+    uncovered_references = tuple(
+        reference
+        for reference in references
+        if not _direct_critical_call_finding_covers_unanalyzed_reference(report, reference)
+    )
+    if not uncovered_references:
+        return report
     notices = (
         *report.notices,
         *(
@@ -6998,7 +7009,7 @@ def _with_unanalyzed_call_graph_notices(
                     "analysis_incomplete": True,
                 },
             )
-            for reference in references
+            for reference in uncovered_references
         ),
     )
     metadata = {**report.to_dict()["metadata"], "analysis_incomplete": True}
@@ -7018,6 +7029,23 @@ def _with_unanalyzed_call_graph_notices(
         private_metadata=report.private_metadata,
         duration_s=report.duration_s,
     )
+
+
+def _direct_critical_call_finding_covers_unanalyzed_reference(
+    report: PickleReport,
+    reference: UnanalyzedCallGraphReference,
+) -> bool:
+    for finding in report.findings:
+        if finding.severity != Severity.CRITICAL or finding.rule_code != "DANGEROUS_CALL":
+            continue
+        module = finding.details.get("module")
+        name = finding.details.get("name")
+        if module == reference.module and name == reference.name:
+            return True
+        import_reference = finding.details.get("import_reference")
+        if import_reference == reference.import_reference:
+            return True
+    return False
 
 
 def _call_graph_import_reference_limit_finding_to_report_finding(report: PickleReport) -> Finding:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -78,6 +78,8 @@ _PICKLE_SECURITY_RELEVANT_OPCODES = frozenset(
         "STACK_GLOBAL",
     }
 )
+_PICKLE_EXTENSION_OPCODES = frozenset({"EXT1", "EXT2", "EXT4"})
+_PICKLE_EXTENSION_EXECUTION_OPCODES = frozenset({"BUILD", "NEWOBJ", "NEWOBJ_EX", "OBJ", "REDUCE"})
 _PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
 _PICKLE_DISCOVERY_LONG_PROBE_BYTES = 64 * 1024
 _TRUSTED_STORAGE_PICKLE_PROBE_BYTES = 4 * 1024
@@ -2082,6 +2084,24 @@ def _looks_like_truncated_security_opcode_prefix(candidate: bytes) -> bool:
     return False
 
 
+def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
+    extension_seen = False
+    try:
+        for opcode, _arg, _pos in pickletools.genops(candidate):
+            if opcode.name in _PICKLE_EXTENSION_OPCODES:
+                extension_seen = True
+                continue
+            if opcode.name == "STOP":
+                return False
+            if extension_seen and opcode.name in _PICKLE_EXTENSION_EXECUTION_OPCODES:
+                return True
+            if opcode.name in {"POP", "POP_MARK"}:
+                extension_seen = False
+    except Exception:
+        return False
+    return False
+
+
 def _trivial_complete_pickle_prefix_trailing_should_scan(
     sample: bytes,
     *,
@@ -2867,6 +2887,8 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             return True
         candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
         candidate_is_prefix = offset + len(candidate) < len(value)
+        if _has_executable_extension_opcode_before_stop(candidate):
+            return True
         if _raw_nested_binary_candidate_should_scan(candidate, candidate_is_prefix=candidate_is_prefix):
             return True
         search_start = offset + 1

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -79,7 +79,7 @@ _PICKLE_SECURITY_RELEVANT_OPCODES = frozenset(
     }
 )
 _PICKLE_EXTENSION_OPCODES = frozenset({"EXT1", "EXT2", "EXT4"})
-_PICKLE_EXTENSION_EXECUTION_OPCODES = frozenset({"BUILD", "NEWOBJ", "NEWOBJ_EX", "OBJ", "REDUCE"})
+_PICKLE_MARK_OPCODE_BYTE = ord("(")
 _PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
 _PICKLE_DISCOVERY_LONG_PROBE_BYTES = 64 * 1024
 _TRUSTED_STORAGE_PICKLE_PROBE_BYTES = 4 * 1024
@@ -2085,18 +2085,120 @@ def _looks_like_truncated_security_opcode_prefix(candidate: bytes) -> bool:
 
 
 def _has_executable_extension_opcode_before_stop(candidate: bytes) -> bool:
-    extension_seen = False
+    stack: list[str] = []
+    memo: dict[str, str] = {}
+
+    def push(value: str) -> None:
+        stack.append(value)
+
+    def pop() -> str:
+        return stack.pop() if stack else "other"
+
+    def pop_until_mark() -> None:
+        while stack:
+            if stack.pop() == "mark":
+                break
+
+    def memo_key(arg: object) -> str:
+        return str(arg)
+
+    def callable_is_extension(offset_from_top: int) -> bool:
+        return len(stack) >= offset_from_top and stack[-offset_from_top] == "extension"
+
     try:
-        for opcode, _arg, _pos in pickletools.genops(candidate):
+        for opcode, arg, _pos in pickletools.genops(candidate):
             if opcode.name in _PICKLE_EXTENSION_OPCODES:
-                extension_seen = True
+                push("extension")
+                continue
+            if opcode.name == "MARK":
+                push("mark")
                 continue
             if opcode.name == "STOP":
                 return False
-            if extension_seen and opcode.name in _PICKLE_EXTENSION_EXECUTION_OPCODES:
-                return True
-            if opcode.name in {"POP", "POP_MARK"}:
-                extension_seen = False
+            if opcode.name == "POP":
+                pop()
+                continue
+            if opcode.name == "POP_MARK":
+                pop_until_mark()
+                continue
+            if opcode.name in {"BINPUT", "LONG_BINPUT", "PUT"}:
+                if stack:
+                    memo[memo_key(arg)] = stack[-1]
+                continue
+            if opcode.name == "MEMOIZE":
+                if stack:
+                    memo[str(len(memo))] = stack[-1]
+                continue
+            if opcode.name in {"BINGET", "LONG_BINGET", "GET"}:
+                push(memo.get(memo_key(arg), "other"))
+                continue
+            if opcode.name == "DUP":
+                push(stack[-1] if stack else "other")
+                continue
+            if opcode.name == "TUPLE":
+                pop_until_mark()
+                push("other")
+                continue
+            if opcode.name in {"LIST", "DICT", "FROZENSET"}:
+                pop_until_mark()
+                push("other")
+                continue
+            if opcode.name in {"APPENDS", "SETITEMS", "ADDITEMS"}:
+                pop_until_mark()
+                continue
+            if opcode.name == "EMPTY_TUPLE":
+                push("other")
+                continue
+            if opcode.name in {"TUPLE1", "TUPLE2", "TUPLE3"}:
+                for _ in range(int(opcode.name[-1])):
+                    pop()
+                push("other")
+                continue
+            if opcode.name == "REDUCE":
+                if callable_is_extension(2):
+                    return True
+                pop()
+                pop()
+                push("other")
+                continue
+            if opcode.name == "NEWOBJ":
+                if callable_is_extension(2):
+                    return True
+                pop()
+                pop()
+                push("other")
+                continue
+            if opcode.name == "NEWOBJ_EX":
+                if callable_is_extension(3):
+                    return True
+                pop()
+                pop()
+                pop()
+                push("other")
+                continue
+            if opcode.name == "OBJ":
+                try:
+                    mark_index = len(stack) - 1 - stack[::-1].index("mark")
+                except ValueError:
+                    mark_index = -1
+                if mark_index >= 0 and mark_index + 1 < len(stack) and stack[mark_index + 1] == "extension":
+                    return True
+                pop_until_mark()
+                push("other")
+                continue
+            if opcode.name == "BUILD":
+                if callable_is_extension(2):
+                    return True
+                pop()
+                pop()
+                push("other")
+                continue
+            if opcode.stack_before:
+                for _ in opcode.stack_before:
+                    pop()
+            if opcode.stack_after:
+                for _ in opcode.stack_after:
+                    push("other")
     except Exception:
         return False
     return False
@@ -2646,8 +2748,15 @@ def _literal_value_has_raw_nested_security_pickle(
             if not fail_closed_on_candidate_budget:
                 return _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value[offset:])
             return _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value[offset:])
-        candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-        candidate_is_prefix = offset + len(candidate) < len(value)
+        candidate_start = (
+            offset - 1
+            if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+            and offset > 0
+            and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE
+            else offset
+        )
+        candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+        candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if marker == 0x80 and _looks_like_binary_pickle_prefix(candidate, sample_is_prefix=candidate_is_prefix):
             if _has_security_relevant_pickle_opcode(candidate):
                 return True
@@ -2885,8 +2994,9 @@ def _raw_nested_extension_opcode_candidate_has_structural_signal(
             return False
         if not _consume_raw_nested_structural_parse_budget(parse_budget_remaining):
             return True
-        candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
-        candidate_is_prefix = offset + len(candidate) < len(value)
+        candidate_start = offset - 1 if offset > 0 and value[offset - 1] == _PICKLE_MARK_OPCODE_BYTE else offset
+        candidate = value[candidate_start : candidate_start + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+        candidate_is_prefix = candidate_start + len(candidate) < len(value)
         if _has_executable_extension_opcode_before_stop(candidate):
             return True
         if _raw_nested_binary_candidate_should_scan(candidate, candidate_is_prefix=candidate_is_prefix):

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2858,7 +2858,10 @@ def _literal_value_has_raw_nested_security_pickle(
             return True
         if marker in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
             if recovered_extension_context:
-                if _has_executable_extension_opcode_before_stop(candidate) or _raw_nested_binary_candidate_should_scan(
+                if _has_executable_extension_opcode_before_stop(
+                    candidate,
+                    fail_closed_on_unknown_after_extension=fail_closed_on_candidate_budget,
+                ) or _raw_nested_binary_candidate_should_scan(
                     candidate,
                     candidate_is_prefix=candidate_is_prefix,
                     nested_literal_depth=nested_literal_depth + 1,
@@ -2867,6 +2870,7 @@ def _literal_value_has_raw_nested_security_pickle(
             elif _raw_nested_extension_opcode_candidate_has_structural_signal(
                 candidate,
                 extension_parse_budget_remaining,
+                fail_closed_on_unknown_after_extension=fail_closed_on_candidate_budget,
             ):
                 return True
         if (

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -1613,16 +1613,8 @@ def _trusted_storage_zip_entry_looks_like_pickle(
                 short_sample,
                 candidate_is_prefix=entry.file_size > len(short_sample),
             )
-            or _raw_nested_extension_opcode_candidate_has_structural_signal(
-                sample,
-                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
-                fail_closed_on_unknown_after_extension=True,
-            )
-            or _raw_nested_extension_opcode_candidate_has_structural_signal(
-                short_sample,
-                [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
-                fail_closed_on_unknown_after_extension=True,
-            )
+            or _headerless_extension_candidate_should_scan_trusted_storage_sample(sample)
+            or _headerless_extension_candidate_should_scan_trusted_storage_sample(short_sample)
         )
         if should_scan:
             return True
@@ -1863,6 +1855,23 @@ def _proto0_or_1_trusted_storage_probe_should_scan(sample: bytes, *, sample_is_p
     if _contains_pickle_frame_opcode(sample):
         return False
     return _looks_like_proto0_or_1_pickle(sample, sample_is_prefix=True)
+
+
+def _headerless_extension_candidate_should_scan_trusted_storage_sample(sample: bytes) -> bool:
+    candidate = sample.lstrip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
+    if not candidate:
+        return False
+    if (
+        candidate[0] not in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+        and candidate[0] != _PICKLE_MARK_OPCODE_BYTE
+        and _complete_headerless_byte_literal_prefix_trailing(sample) is None
+    ):
+        return False
+    return _raw_nested_extension_opcode_candidate_has_structural_signal(
+        sample,
+        [_MAX_RAW_NESTED_PICKLE_CANDIDATES],
+        fail_closed_on_unknown_after_extension=True,
+    )
 
 
 def _proto0_or_1_trusted_storage_probe_needs_expanded_sample(sample: bytes, *, entry_size: int | None = None) -> bool:
@@ -2912,11 +2921,35 @@ def _trailing_candidate_has_raw_nested_security_pickle(
 
 
 def _raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:
-    if _raw_nested_security_pickle_text_marker_seen(value):
-        return True
-    if value and value[0] in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES:
-        return True
+    if _budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value):
+        return False
     return _raw_nested_security_pickle_candidate_has_structural_signal(value)
+
+
+def _budget_exhausted_suffix_is_only_incomplete_extension_after_text_noise(value: bytes) -> bool:
+    if _raw_nested_proto0_global_ref_seen(value):
+        return False
+    extension_offsets = [
+        offset
+        for offset, byte in enumerate(value[:_MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES])
+        if byte in _BINARY_EXTENSION_SECURITY_OPCODE_BYTES
+    ]
+    if len(extension_offsets) != 1:
+        return False
+    offset = extension_offsets[0]
+    prefix = value[:offset]
+    if not prefix or any(
+        byte not in _PROTO0_GLOBAL_NAME_BYTES and byte not in _PROTO0_1_IGNORABLE_TRAILING_BYTES for byte in prefix
+    ):
+        return False
+    candidate = value[offset : offset + _MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES]
+    if _extension_candidate_after_exhausted_context_should_scan(candidate):
+        return False
+    if offset + len(candidate) < len(value):
+        return False
+    operand_len = {0x82: 1, 0x83: 2, 0x84: 4}[candidate[0]]
+    trailing = candidate[1 + operand_len :]
+    return not trailing or not trailing.strip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
 
 
 def _encoded_raw_nested_security_pickle_candidate_budget_exhausted_needs_scan(value: bytes) -> bool:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4316,6 +4316,65 @@ def test_trusted_storage_probe_routes_headerless_binary_stream_at_entry_gate(tmp
     assert looks_like_pickle is True
 
 
+def test_trusted_storage_probe_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:
+    storage = b"hello"
+    for _ in range(19):
+        literal_pickle = b"B" + len(storage).to_bytes(4, "little") + storage + b"."
+        storage = b"\x95" + len(literal_pickle).to_bytes(8, "little") + literal_pickle
+    archive_path = tmp_path / "nested-byte-literal-storage.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        started = time.monotonic()
+        looks_like_pickle = package_api._trusted_storage_zip_entry_looks_like_pickle(
+            archive,
+            entry,
+            [package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+            started + 0.1,
+        )
+
+    assert looks_like_pickle is True
+    assert time.monotonic() - started < 1.0
+
+
+def test_trusted_storage_probe_bounds_trailing_literal_discovery(tmp_path: Path) -> None:
+    archive_path = tmp_path / "trailing-literal-chain.pt"
+    storage = b"\x8c\x00." * 20
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        started = time.monotonic()
+        looks_like_pickle = package_api._trusted_storage_zip_entry_looks_like_pickle(
+            archive,
+            entry,
+            [package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+            started + 0.1,
+        )
+
+    assert looks_like_pickle is True
+    assert time.monotonic() - started < 1.0
+
+
+@pytest.mark.parametrize(
+    "storage",
+    [
+        pytest.param(b"\x8c\x00." * 20, id="empty-short-binunicode-chain"),
+        pytest.param((b"\x95" + (2).to_bytes(8, "little") + b"N.") * 20, id="frame-none-chain"),
+    ],
+)
+def test_raw_nested_binary_candidate_bounds_trailing_literal_discovery(storage: bytes) -> None:
+    started = time.monotonic()
+
+    should_scan = package_api._raw_nested_binary_candidate_should_scan(storage, candidate_is_prefix=False)
+
+    assert should_scan is True
+    assert time.monotonic() - started < 1.0
+
+
 def test_expanded_trusted_storage_probe_checks_long_window_before_padding_budget(tmp_path: Path) -> None:
     malicious_suffix = b"cposix\nsystem\n(S'echo long-before-padding'\ntR."
     storage = b"N." + (b" " * (package_api._TRUSTED_STORAGE_PICKLE_PROBE_BYTES - len(b"N.")))
@@ -8108,6 +8167,51 @@ def test_scan_file_routes_long_headerless_binbytes_storage(tmp_path: Path) -> No
     )
 
 
+def test_scan_file_routes_padded_headerless_byte_literal_storage(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    storage_blob = b"C\x06benign." + (b" " * 5000) + b"cposix\nsystem\n)R."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/data/0" in finding.location
+        for finding in report.findings
+    )
+
+
+def test_scan_file_routes_redundantly_padded_base64_literal_storage(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    encoded = base64.b64encode(b"cposix\nsystem\n)R.") + b"="
+    storage_blob = b"S'" + encoded + b"'\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/data/0" in finding.location
+        for finding in report.findings
+    )
+
+
 def test_scan_file_skips_direct_headerless_byte_literal_near_match(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
     storage_blob = b"C\x06benign."
@@ -8123,6 +8227,24 @@ def test_scan_file_skips_direct_headerless_byte_literal_near_match(tmp_path: Pat
     assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.CLEAN
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
+
+
+def test_scan_file_skips_impossible_headerless_binbytes_length(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    storage_blob = b"B" + (10_000_000).to_bytes(4, "little") + (b"\x00\x00\x80\x3f" * 2048)
+    storage_blob += b"\x00" * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
+    assert not any(finding.details.get("pickle_filename") == "archive/data/0" for finding in report.findings)
 
 
 def test_scan_file_keeps_long_headerless_binbytes_near_match_clean(tmp_path: Path) -> None:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4436,6 +4436,26 @@ def test_scan_file_routes_extension_callable_in_referenced_storage(
     )
 
 
+def test_scan_file_routes_raw_literal_extension_before_unknown_opcode(tmp_path: Path) -> None:
+    storage = _proto0_string_literal(b"\x82\x01\xff")
+    storage += b" " * (-len(storage) % 4)
+    archive_path = tmp_path / "raw-extension-before-unknown-opcode-storage.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        notice.code == "parse_incomplete" and "archive/data/0" in str(notice.location) for notice in report.notices
+    )
+
+
 def _budget_exhausted_headerless_extension_literal() -> bytes:
     payload = b"c" * (package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)
     return b"C" + bytes([len(payload)]) + payload + b"0\x82\x01"
@@ -8694,6 +8714,10 @@ def test_raw_nested_literal_candidates_fail_closed_after_budget(monkeypatch: pyt
 
 def test_raw_nested_literal_routes_extension_operand_after_budget_exhaustion() -> None:
     assert package_api._literal_value_has_raw_nested_security_pickle(_budget_exhausted_headerless_extension_literal())
+
+
+def test_raw_nested_literal_routes_extension_before_unknown_opcode() -> None:
+    assert package_api._literal_value_has_raw_nested_security_pickle(b"\x82\x01\xff") is True
 
 
 def test_raw_nested_literal_preserves_text_marker_after_budget_exhaustion() -> None:
@@ -19503,7 +19527,13 @@ def test_raw_nested_extension_routes_headerless_literal_extension_tail() -> None
 def test_literal_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
     remaining_budget_seen: list[int] = []
 
-    def no_signal(_candidate: bytes, parse_budget_remaining: list[int]) -> bool:
+    def no_signal(
+        _candidate: bytes,
+        parse_budget_remaining: list[int],
+        *,
+        fail_closed_on_unknown_after_extension: bool = False,
+    ) -> bool:
+        assert fail_closed_on_unknown_after_extension is True
         remaining_budget_seen.append(parse_budget_remaining[0])
         package_api._consume_raw_nested_structural_parse_budget(parse_budget_remaining)
         return False

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -19084,6 +19084,19 @@ def test_scan_file_scans_binary_storage_member_inside_expanded_probe_window(tmp_
     )
 
 
+def test_raw_nested_extension_reduce_candidate_routes_without_stop() -> None:
+    executable_candidate = base64.b64decode("ggEpUg==")
+
+    assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        executable_candidate,
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+    assert not package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        executable_candidate[:-1],
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+
+
 @pytest.mark.parametrize(
     ("pickle_prefix", "case_name"),
     [

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4298,6 +4298,24 @@ def test_expanded_trusted_storage_probe_preserves_short_frame_probe(tmp_path: Pa
     ]
 
 
+def test_expanded_trusted_storage_probe_fails_closed_for_unread_headerless_padding(tmp_path: Path) -> None:
+    storage = b"C\x01x." + (b" " * (package_api._PICKLE_DISCOVERY_PADDING_PROBE_BYTES + 1))
+    archive_path = tmp_path / "headerless-padding-storage.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        with pytest.raises(ValueError, match="trusted PyTorch storage padding probe limit reached"):
+            package_api._trusted_storage_zip_entry_looks_like_pickle(
+                archive,
+                entry,
+                [2 * package_api._PICKLE_DISCOVERY_PADDING_PROBE_BYTES],
+                float("inf"),
+                max_probe_bytes=package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+            )
+
+
 def test_trusted_storage_probe_routes_headerless_binary_stream_at_entry_gate(tmp_path: Path) -> None:
     storage = _short_binunicode(b"os") + _short_binunicode(b"system") + b"\x93)R."
     archive_path = tmp_path / "headerless-binary-storage.pt"
@@ -8466,6 +8484,30 @@ def test_scan_file_keeps_long_headerless_binbytes_near_match_clean(tmp_path: Pat
     assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.CLEAN
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
+def test_scan_file_routes_exact_fit_binbytes_storage_without_stop(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    byte_literal = (b"A" * 5002) + b"cposix\nsystem\n)R."
+    storage_blob = b"B" + len(byte_literal).to_bytes(4, "little") + byte_literal
+    assert len(storage_blob) == 5024
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/data/0" in finding.location
+        for finding in report.findings
+    )
 
 
 @pytest.mark.parametrize(
@@ -19327,6 +19369,18 @@ def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callabl
     )
 
 
+def test_raw_nested_extension_routes_unknown_opcode_when_fail_closed_requested() -> None:
+    assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"\x82\x01\xff",
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+        fail_closed_on_unknown_after_extension=True,
+    )
+    assert not package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"\x82\x01\xff",
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+
+
 def test_raw_nested_extension_boundary_recovery_charges_shared_budget() -> None:
     malformed_candidate = b"(" * 256 + b"\xff\x82\x01."
     parse_budget_remaining = [3]
@@ -19336,6 +19390,23 @@ def test_raw_nested_extension_boundary_recovery_charges_shared_budget() -> None:
         parse_budget_remaining,
     )
     assert parse_budget_remaining == [0]
+
+
+def test_raw_nested_extension_routes_live_mark_after_context_budget_exhaustion() -> None:
+    value = (b"(\xff" * package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES) + b"(](NNNe0\x82\x01)o"
+
+    assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        value,
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+    assert package_api._literal_value_has_raw_nested_security_pickle(value)
+
+
+def test_raw_nested_extension_routes_headerless_literal_extension_tail() -> None:
+    assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"C\x01x0\x82\x01",
+        [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
 
 
 def test_literal_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4348,10 +4348,28 @@ def test_trusted_storage_probe_routes_encoded_extension_callable_after_pop(
     assert looks_like_pickle is True
 
 
-def test_trusted_storage_probe_skips_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
+def test_trusted_storage_probe_routes_truncated_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
     encoded_removed_extension_literal = base64.b64encode(b"\x82\x010)R")
     storage = b"C" + bytes([len(encoded_removed_extension_literal)]) + encoded_removed_extension_literal + b"."
-    archive_path = tmp_path / "headerless-extension-storage-removed.pt"
+    archive_path = tmp_path / "headerless-extension-storage-removed-truncated.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = package_api._trusted_storage_zip_entry_looks_like_pickle(
+            archive,
+            entry,
+            [package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+            float("inf"),
+        )
+
+    assert looks_like_pickle is True
+
+
+def test_trusted_storage_probe_skips_raw_extension_bytes_in_nonpickle_storage(tmp_path: Path) -> None:
+    storage = b"tensor-storage-bytes:\x82\x01:not-a-pickle"
+    archive_path = tmp_path / "headerless-extension-storage-raw-data.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("archive/data/0", storage)
 
@@ -19182,6 +19200,8 @@ def test_scan_file_scans_binary_storage_member_inside_expanded_probe_window(tmp_
         b"\x82\x01(Ne",
         b"\x82\x01(NNu",
         b"\x82\x01(N\x90",
+        b"\x82\x01",
+        b"(C\x02(.0\x82\x01o",
     ],
 )
 def test_raw_nested_extension_reduce_candidate_routes_without_stop(executable_candidate: bytes) -> None:
@@ -19194,11 +19214,7 @@ def test_raw_nested_extension_reduce_candidate_routes_without_stop(executable_ca
 @pytest.mark.parametrize(
     "benign_candidate",
     [
-        b"\x82\x010)R",
-        b"\x82\x01N)R",
-        base64.b64decode("ggEpUg==")[:-1],
-        b"(0\x82\x01o",
-        b"N\x82\x01a",
+        b"(C\x02\x82\x01o",
     ],
 )
 def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callable(benign_candidate: bytes) -> None:
@@ -19206,6 +19222,17 @@ def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callabl
         benign_candidate,
         [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+def test_raw_nested_extension_boundary_recovery_charges_shared_budget() -> None:
+    malformed_candidate = b"(" * 256 + b"\xff\x82\x01."
+    parse_budget_remaining = [3]
+
+    assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        malformed_candidate,
+        parse_budget_remaining,
+    )
+    assert parse_budget_remaining == [0]
 
 
 def test_literal_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -19236,6 +19263,19 @@ def test_literal_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: 
 )
 def test_scan_bytes_reports_raw_nested_extension_callable_after_pop(nested_payload: bytes) -> None:
     report = scan_bytes(_proto0_string_literal(nested_payload), source="raw-extension-live.pkl")
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("module") == "copyreg.extension"
+        and finding.details.get("name") == "code_1"
+        for finding in report.findings
+    )
+
+
+def test_scan_bytes_reports_raw_nested_extension_with_literal_stop_like_operand() -> None:
+    report = scan_bytes(_proto0_string_literal(b"(C\x02(.0\x82\x01o"), source="raw-extension-mark-context.pkl")
 
     assert report.status == ScanStatus.INCONCLUSIVE
     assert report.verdict == SafetyVerdict.MALICIOUS

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -6789,6 +6789,24 @@ def test_scan_file_routes_nested_extension_reference_literal_storage(tmp_path: P
     assert any(finding.rule_code == "EXTENSION_REF" for finding in report.findings)
 
 
+def test_scan_file_routes_base64_extension_reduce_literal_storage(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    storage_blob = b"S'ggFOMClSLg=='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "S601" for finding in report.findings)
+    assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+
+
 @pytest.mark.parametrize(
     ("memo_prefix", "memo_suffix"),
     [

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -6015,6 +6015,109 @@ def test_scan_file_scans_extension_opcode_crossing_trusted_probe_boundary(tmp_pa
     )
 
 
+def test_scan_file_routes_encoded_extension_with_truncated_operand(tmp_path: Path) -> None:
+    archive_path = tmp_path / "truncated-extension-operand.pt"
+    storage_blob = b"S'ggFxAIwFeA=='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
+def test_scan_file_routes_encoded_extension_with_live_mark_context(tmp_path: Path) -> None:
+    archive_path = tmp_path / "live-mark-extension.pt"
+    storage_blob = b"S'KE4wggEpb/8='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
+def test_scan_file_routes_nested_mark_extension_context(tmp_path: Path) -> None:
+    archive_path = tmp_path / "nested-mark-extension.pt"
+    payload = b"(N(N10\x82\x01)o\xff"
+    storage_blob = b"C" + bytes([len(payload)]) + payload + b"."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict != SafetyVerdict.CLEAN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\x82\x01q\x00\xff",
+        (b"N." * 70) + b"(\x82\x01)R\xff",
+    ],
+)
+def test_scan_file_routes_encoded_extension_fail_closed_suffixes(tmp_path: Path, payload: bytes) -> None:
+    archive_path = tmp_path / "extension-fail-closed-suffix.pt"
+    storage_blob = b"S'" + base64.b64encode(payload) + b"'\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict != SafetyVerdict.CLEAN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"(" * 20 + b"\xff" + (b"\x82\x01\xff" * 4) + b"\x82\x01)R.",
+        (b"(" * 10) + b"\xff" + (b"\x82\x01\xff" * 10) + b"cposix\nsystem\n)R.",
+    ],
+)
+def test_scan_file_preserves_later_payload_after_exhausted_extension_context(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    archive_path = tmp_path / "extension-exhausted-context-later-payload.pt"
+    storage_blob = b"C" + bytes([len(payload)]) + payload + b"."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+
+
 def test_scan_file_scans_repeated_trivial_prefix_crossing_trusted_probe_boundary(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
     storage_blob = b"N.N." + (b" " * (4096 - 4 - 5)) + b"cposix\nsystem\n(S'echo hidden'\ntR."

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -19176,6 +19176,12 @@ def test_scan_file_scans_binary_storage_member_inside_expanded_probe_window(tmp_
         b"\x82\x01q\x00N\x9400h\x00)R",
         b"\x82\x01q\x00](NNNe0)R",
         b"(\x82\x01)o",
+        b"(N0\x82\x01o",
+        b"\x82\x01Na",
+        b"\x82\x01NNs",
+        b"\x82\x01(Ne",
+        b"\x82\x01(NNu",
+        b"\x82\x01(N\x90",
     ],
 )
 def test_raw_nested_extension_reduce_candidate_routes_without_stop(executable_candidate: bytes) -> None:
@@ -19191,6 +19197,8 @@ def test_raw_nested_extension_reduce_candidate_routes_without_stop(executable_ca
         b"\x82\x010)R",
         b"\x82\x01N)R",
         base64.b64decode("ggEpUg==")[:-1],
+        b"(0\x82\x01o",
+        b"N\x82\x01a",
     ],
 )
 def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callable(benign_candidate: bytes) -> None:
@@ -19198,6 +19206,25 @@ def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callabl
         benign_candidate,
         [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+def test_literal_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    remaining_budget_seen: list[int] = []
+
+    def no_signal(_candidate: bytes, parse_budget_remaining: list[int]) -> bool:
+        remaining_budget_seen.append(parse_budget_remaining[0])
+        package_api._consume_raw_nested_structural_parse_budget(parse_budget_remaining)
+        return False
+
+    monkeypatch.setattr(package_api, "_raw_nested_extension_opcode_candidate_has_structural_signal", no_signal)
+
+    assert not package_api._literal_value_has_raw_nested_security_pickle(b"\x82\x010" * 4)
+    assert remaining_budget_seen == [
+        package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES,
+        package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES - 1,
+        package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES - 2,
+        package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES - 3,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4316,6 +4316,89 @@ def test_trusted_storage_probe_routes_headerless_binary_stream_at_entry_gate(tmp
     assert looks_like_pickle is True
 
 
+@pytest.mark.parametrize(
+    ("encoded_extension_literal", "case_name"),
+    [
+        (b"ggFOMClS", "pop-removes-later-none"),
+        (b"ggEoTjEpUg==", "pop-mark-removes-later-mark"),
+        (base64.b64encode(b"\x82\x01q\x00N\x9400h\x00)R"), "explicit-memo-before-memoize"),
+        (base64.b64encode(b"\x82\x01q\x00](NNNe0)R"), "mark-delimited-appends-before-pop"),
+        (base64.b64encode(b"(\x82\x01)o"), "obj-mark-before-extension"),
+    ],
+)
+def test_trusted_storage_probe_routes_encoded_extension_callable_after_pop(
+    tmp_path: Path,
+    encoded_extension_literal: bytes,
+    case_name: str,
+) -> None:
+    storage = b"C" + bytes([len(encoded_extension_literal)]) + encoded_extension_literal + b"."
+    archive_path = tmp_path / f"headerless-extension-storage-{case_name}.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = package_api._trusted_storage_zip_entry_looks_like_pickle(
+            archive,
+            entry,
+            [package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+            float("inf"),
+        )
+
+    assert looks_like_pickle is True
+
+
+def test_trusted_storage_probe_skips_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
+    encoded_removed_extension_literal = base64.b64encode(b"\x82\x010)R")
+    storage = b"C" + bytes([len(encoded_removed_extension_literal)]) + encoded_removed_extension_literal + b"."
+    archive_path = tmp_path / "headerless-extension-storage-removed.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = package_api._trusted_storage_zip_entry_looks_like_pickle(
+            archive,
+            entry,
+            [package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+            float("inf"),
+        )
+
+    assert looks_like_pickle is False
+
+
+@pytest.mark.parametrize(
+    ("payload", "case_name"),
+    [
+        (b"\x82\x01q\x00N\x9400h\x00)R", "memoized-extension"),
+        (b"\x82\x01q\x00](NNNe0)R", "mark-delimited-appends-extension"),
+        (b"(\x82\x01)o", "obj-mark-extension"),
+    ],
+)
+def test_scan_file_routes_extension_callable_in_referenced_storage(
+    tmp_path: Path,
+    payload: bytes,
+    case_name: str,
+) -> None:
+    storage = _proto0_string_literal(base64.b64encode(payload))
+    storage += b" " * (-len(storage) % 4)
+    archive_path = tmp_path / f"{case_name}-storage.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        notice.code == "parse_incomplete" and "archive/data/0" in str(notice.location) for notice in report.notices
+    )
+
+
 def test_trusted_storage_probe_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:
     storage = b"hello"
     for _ in range(19):
@@ -19084,17 +19167,63 @@ def test_scan_file_scans_binary_storage_member_inside_expanded_probe_window(tmp_
     )
 
 
-def test_raw_nested_extension_reduce_candidate_routes_without_stop() -> None:
-    executable_candidate = base64.b64decode("ggEpUg==")
-
+@pytest.mark.parametrize(
+    "executable_candidate",
+    [
+        base64.b64decode("ggEpUg=="),
+        base64.b64decode("ggFOMClS"),
+        base64.b64decode("ggEoTjEpUg=="),
+        b"\x82\x01q\x00N\x9400h\x00)R",
+        b"\x82\x01q\x00](NNNe0)R",
+        b"(\x82\x01)o",
+    ],
+)
+def test_raw_nested_extension_reduce_candidate_routes_without_stop(executable_candidate: bytes) -> None:
     assert package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
         executable_candidate,
         [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+@pytest.mark.parametrize(
+    "benign_candidate",
+    [
+        b"\x82\x010)R",
+        b"\x82\x01N)R",
+        base64.b64decode("ggEpUg==")[:-1],
+    ],
+)
+def test_raw_nested_extension_reduce_candidate_skips_removed_or_shadowed_callable(benign_candidate: bytes) -> None:
     assert not package_api._raw_nested_extension_opcode_candidate_has_structural_signal(
-        executable_candidate[:-1],
+        benign_candidate,
         [package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+@pytest.mark.parametrize(
+    "nested_payload",
+    [
+        b"\x82\x01N0)R",
+        b"\x82\x01(N1)R",
+    ],
+)
+def test_scan_bytes_reports_raw_nested_extension_callable_after_pop(nested_payload: bytes) -> None:
+    report = scan_bytes(_proto0_string_literal(nested_payload), source="raw-extension-live.pkl")
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("module") == "copyreg.extension"
+        and finding.details.get("name") == "code_1"
+        for finding in report.findings
+    )
+
+
+def test_scan_bytes_keeps_raw_nested_extension_removed_by_pop_clean() -> None:
+    report = scan_bytes(_proto0_string_literal(b"\x82\x010)R"), source="raw-extension-removed.pkl")
+
+    _assert_clean_report(report)
 
 
 @pytest.mark.parametrize(

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -18,6 +18,7 @@ import os
 import pickle
 import py_compile
 import re
+import struct
 import subprocess
 import sys
 import tarfile
@@ -4435,6 +4436,47 @@ def test_scan_file_routes_extension_callable_in_referenced_storage(
     )
 
 
+def _budget_exhausted_headerless_extension_literal() -> bytes:
+    payload = b"c" * (package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)
+    return b"C" + bytes([len(payload)]) + payload + b"0\x82\x01"
+
+
+def _budget_exhausted_truncated_inst_literal() -> bytes:
+    padding = b"c" * package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES
+    return padding + b"iposix\nsystem\n"
+
+
+@pytest.mark.parametrize(
+    ("literal", "case_name"),
+    [
+        (_budget_exhausted_headerless_extension_literal(), "extension-after-headerless-literal-budget"),
+        (_budget_exhausted_truncated_inst_literal(), "inst-after-candidate-budget"),
+    ],
+)
+def test_scan_file_routes_budget_exhausted_referenced_storage(
+    tmp_path: Path,
+    literal: bytes,
+    case_name: str,
+) -> None:
+    storage = _proto0_string_literal(literal)
+    storage += b" " * (-len(storage) % 4)
+    archive_path = tmp_path / f"{case_name}-storage.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        notice.code == "parse_incomplete" and "archive/data/0" in str(notice.location) for notice in report.notices
+    )
+
+
 def test_trusted_storage_probe_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:
     storage = b"hello"
     for _ in range(19):
@@ -8648,6 +8690,14 @@ def test_raw_nested_literal_candidates_fail_closed_after_budget(monkeypatch: pyt
 
     assert package_api._literal_value_has_raw_nested_security_pickle(value) is False
     assert calls == package_api._MAX_RAW_NESTED_PICKLE_CANDIDATES
+
+
+def test_raw_nested_literal_routes_extension_operand_after_budget_exhaustion() -> None:
+    assert package_api._literal_value_has_raw_nested_security_pickle(_budget_exhausted_headerless_extension_literal())
+
+
+def test_raw_nested_literal_preserves_text_marker_after_budget_exhaustion() -> None:
+    assert package_api._literal_value_has_raw_nested_security_pickle(_budget_exhausted_truncated_inst_literal())
 
 
 def test_raw_nested_structural_fallback_bounds_binary_opcode_candidates(
@@ -16990,6 +17040,47 @@ def test_unanalyzed_call_graph_notice_preserves_suspicious_verdict() -> None:
     assert updated.verdict == SafetyVerdict.SUSPICIOUS
     assert updated.findings == (finding,)
     assert updated.metadata["analysis_incomplete"] is True
+
+
+class DirectSystemPayload:
+    def __reduce__(self) -> tuple[Any, tuple[str]]:
+        return (os.system, ("id",))
+
+
+def _alternate_platform_system_reduce_payload() -> tuple[bytes, str]:
+    native_module = b"nt" if os.name == "nt" else b"posix"
+    alternate_module = b"posix" if native_module == b"nt" else b"nt"
+    payload = pickle.dumps(
+        {
+            "state_dict": collections.OrderedDict([("layer.weight", "tensor_data")]),
+            "payload": DirectSystemPayload(),
+        },
+        protocol=4,
+    )
+    native_token = _short_binunicode(native_module)
+    alternate_token = _short_binunicode(alternate_module)
+    assert native_token in payload
+    payload = payload.replace(native_token, alternate_token, 1)
+    if payload.startswith(b"\x80\x04\x95"):
+        payload = payload[:3] + struct.pack("<Q", len(payload) - 11) + payload[11:]
+    return payload, f"{alternate_module.decode()}.system"
+
+
+def test_direct_dangerous_call_suppresses_redundant_source_unavailable_notice() -> None:
+    payload, import_reference = _alternate_platform_system_reduce_payload()
+
+    report = scan_bytes(payload, source="direct-platform-system.pkl")
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL" and finding.details.get("import_reference") == import_reference
+        for finding in report.findings
+    )
+    assert not any(
+        notice.code == "call_graph_source_unavailable" and notice.details.get("import_reference") == import_reference
+        for notice in report.notices
+    )
 
 
 def test_with_call_graph_findings_preserves_startup_hook_findings_before_limit_error(

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -6,11 +6,13 @@ import os
 import pickle
 import struct
 import time
+import zipfile
 from collections.abc import Mapping
+from pathlib import Path
 
 import pytest
 
-from modelaudit_picklescan import SafetyVerdict, ScanOptions, ScanStatus, scan_bytes
+from modelaudit_picklescan import SafetyVerdict, ScanOptions, ScanStatus, scan_bytes, scan_file
 from modelaudit_picklescan import api as picklescan_api
 
 MAX_PROTOCOL0_LINE_OPERAND_BYTES = 8 * 1024 * 1024
@@ -62,6 +64,27 @@ def _proto0_string_literal(value: bytes) -> bytes:
 
 def _binbytes_literal_pickle(value: bytes) -> bytes:
     return b"B" + struct.pack("<I", len(value)) + value + b"."
+
+
+def _short_binunicode(data: bytes) -> bytes:
+    assert len(data) < 256
+    return b"\x8c" + bytes([len(data)]) + data
+
+
+def _float_storage_persistent_id_payload_for_bytes(key: str, data: bytes) -> bytes:
+    element_count = max(1, len(data) // 4)
+    return (
+        b"\x80\x04("
+        + _short_binunicode(b"storage")
+        + _short_binunicode(b"torch")
+        + _short_binunicode(b"FloatStorage")
+        + b"\x93"
+        + _short_binunicode(key.encode("ascii"))
+        + _short_binunicode(b"cpu")
+        + b"K"
+        + bytes([element_count])
+        + b"tQ."
+    )
 
 
 def _frame(payload: bytes) -> bytes:
@@ -1074,10 +1097,66 @@ def test_trusted_storage_probe_skips_incomplete_extension_opcode_after_budget_no
     assert not picklescan_api._literal_value_has_raw_nested_security_pickle(literal)
 
 
+def test_trusted_storage_probe_routes_later_pickle_after_incomplete_extension_budget_noise() -> None:
+    nested_pickle = b"\x80\x04\x8c\x08builtins\x8c\x04eval\x93\x8c\x031+1\x85R."
+    literal = (
+        (b"c" * (picklescan_api._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1))
+        + (b"A" * 10)
+        + b"\x82\x01"
+        + (b" " * picklescan_api._MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES)
+        + nested_pickle
+    )
+
+    assert picklescan_api._literal_value_has_raw_nested_security_pickle(literal)
+
+
+def test_raw_nested_extension_budget_exhaustion_routes_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    literal = (
+        (b"c" * (picklescan_api._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1))
+        + (b"(" * (picklescan_api._MAX_RAW_NESTED_PICKLE_CANDIDATES + 6))
+        + b"\xff"
+        + (b"\x82\x01" * 1900)
+    )
+
+    def fail_if_called(_candidate: bytes) -> bool:
+        raise AssertionError("fallback parser should not run after extension context budget exhaustion")
+
+    monkeypatch.setattr(
+        picklescan_api,
+        "_extension_candidate_after_exhausted_context_should_scan",
+        fail_if_called,
+    )
+    parse_budget_remaining = [picklescan_api._MAX_RAW_NESTED_PICKLE_CANDIDATES]
+
+    assert picklescan_api._raw_nested_extension_opcode_candidate_has_structural_signal(
+        literal,
+        parse_budget_remaining,
+    )
+    assert parse_budget_remaining == [0]
+
+
 def test_trusted_storage_probe_routes_legacy_raw_candidate_budget_exhaustion() -> None:
     literal = (b"\x82" * 65) + (b"\xff" * 16)
 
     assert picklescan_api._literal_value_has_raw_nested_security_pickle(literal)
+
+
+def test_scan_file_keeps_float_storage_extension_like_bytes_clean(tmp_path: Path) -> None:
+    storage_blob = b"\x8c\x01\xff\x3f\x82\x01\xff\x3f"
+    model_path = tmp_path / "float-storage-extension-like-bytes.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(model_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert tuple(report.metadata.get("pickle_files", ())) == ("archive/data.pkl",)
 
 
 def test_trusted_storage_probe_routes_encoded_pickle_after_binary_candidate_budget_noise() -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -5359,6 +5359,74 @@ def test_pytorch_zip_trusted_storage_routes_headerless_byte_literal_at_entry_gat
     assert looks_like_pickle is True
 
 
+def test_pytorch_zip_trusted_storage_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:
+    archive_path = tmp_path / "nested_byte_literal_storage.pt"
+    storage_blob = b"hello"
+    for _ in range(19):
+        literal_pickle = b"B" + len(storage_blob).to_bytes(4, "little") + storage_blob + b"."
+        storage_blob = b"\x95" + len(literal_pickle).to_bytes(8, "little") + literal_pickle
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = ScanResult(scanner_name="pytorch_zip")
+    scanner = PyTorchZipScanner()
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        entry = archive.getinfo("archive/data/0")
+        started = time.monotonic()
+        looks_like_pickle = scanner._trusted_storage_entry_looks_like_pickle(
+            archive,
+            entry,
+            result,
+            padding_probe_bytes_remaining=[pytorch_zip_scanner_module._PICKLE_DISCOVERY_PADDING_PROBE_BUDGET_BYTES],
+        )
+
+    assert looks_like_pickle is True
+    assert time.monotonic() - started < 1.0
+
+
+def test_pytorch_zip_trusted_storage_bounds_trailing_literal_discovery(tmp_path: Path) -> None:
+    archive_path = tmp_path / "trailing_literal_storage.pt"
+    storage_blob = b"\x8c\x00." * 20
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = ScanResult(scanner_name="pytorch_zip")
+    scanner = PyTorchZipScanner()
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        entry = archive.getinfo("archive/data/0")
+        started = time.monotonic()
+        looks_like_pickle = scanner._trusted_storage_entry_looks_like_pickle(
+            archive,
+            entry,
+            result,
+            padding_probe_bytes_remaining=[pytorch_zip_scanner_module._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+        )
+
+    assert looks_like_pickle is True
+    assert time.monotonic() - started < 1.0
+
+
+@pytest.mark.parametrize(
+    "storage_blob",
+    [
+        pytest.param(b"\x8c\x00." * 20, id="empty-short-binunicode-chain"),
+        pytest.param((b"\x95" + (2).to_bytes(8, "little") + b"N.") * 20, id="frame-none-chain"),
+    ],
+)
+def test_pytorch_zip_raw_nested_binary_candidate_bounds_trailing_literal_discovery(storage_blob: bytes) -> None:
+    started = time.monotonic()
+
+    should_scan = PyTorchZipScanner._raw_nested_binary_candidate_should_scan(
+        storage_blob,
+        candidate_is_prefix=False,
+    )
+
+    assert should_scan is True
+    assert time.monotonic() - started < 1.0
+
+
 def test_pytorch_zip_discovery_routes_direct_headerless_byte_literal_storage(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_headerless_byte_literal_storage.pt"
     encoded = base64.b64encode(b"cposix\nsystem\n)R.")
@@ -5399,9 +5467,67 @@ def test_pytorch_zip_discovery_routes_long_headerless_binbytes_storage(tmp_path:
     )
 
 
+def test_pytorch_zip_discovery_routes_padded_headerless_byte_literal_storage(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_padded_headerless_byte_literal_storage.pt"
+    storage_blob = b"C\x06benign." + (b" " * 5000) + b"cposix\nsystem\n)R."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
+def test_pytorch_zip_discovery_routes_redundantly_padded_base64_literal_storage(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_redundantly_padded_base64_literal_storage.pt"
+    encoded = base64.b64encode(b"cposix\nsystem\n)R.") + b"="
+    storage_blob = b"S'" + encoded + b"'\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_discovery_skips_direct_headerless_byte_literal_near_match(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_headerless_byte_literal_near_match.pt"
     storage_blob = b"C\x06benign."
+    storage_blob += b"\x00" * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "clean"
+    assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
+    assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
+
+
+def test_pytorch_zip_discovery_skips_impossible_headerless_binbytes_length(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_impossible_headerless_binbytes_length.pt"
+    storage_blob = b"B" + (10_000_000).to_bytes(4, "little") + (b"\x00\x00\x80\x3f" * 2048)
     storage_blob += b"\x00" * (-len(storage_blob) % 4)
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3394,7 +3394,13 @@ def test_pytorch_zip_raw_nested_extension_routes_headerless_literal_extension_ta
 def test_pytorch_zip_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
     remaining_budget_seen: list[int] = []
 
-    def no_signal(_candidate: bytes, parse_budget_remaining: list[int]) -> bool:
+    def no_signal(
+        _candidate: bytes,
+        parse_budget_remaining: list[int],
+        *,
+        fail_closed_on_unknown_after_extension: bool = False,
+    ) -> bool:
+        assert fail_closed_on_unknown_after_extension is True
         remaining_budget_seen.append(parse_budget_remaining[0])
         PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining)
         return False
@@ -5823,6 +5829,27 @@ def test_pytorch_zip_scan_routes_extension_callable_in_referenced_storage(
     )
 
 
+def test_pytorch_zip_scan_routes_raw_literal_extension_before_unknown_opcode(tmp_path: Path) -> None:
+    archive_path = tmp_path / "raw_extension_before_unknown_opcode_storage.pt"
+    storage_blob = _proto0_string_literal(b"\x82\x01\xff")
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(archive_path))
+
+    assert result.success is False
+    assert result.metadata.get("pickle_verdict") == "unknown"
+    assert result.metadata.get("pickle_files") == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        issue.rule_code == "S902" and issue.location is not None and "archive/data/0" in issue.location
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_trusted_storage_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:
     archive_path = tmp_path / "nested_byte_literal_storage.pt"
     storage_blob = b"hello"
@@ -6390,6 +6417,10 @@ def test_pytorch_zip_raw_nested_literal_routes_extension_operand_after_budget_ex
     assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(
         _budget_exhausted_headerless_extension_literal()
     )
+
+
+def test_pytorch_zip_raw_nested_literal_routes_extension_before_unknown_opcode() -> None:
+    assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(b"\x82\x01\xff") is True
 
 
 def test_pytorch_zip_raw_nested_literal_preserves_text_marker_after_budget_exhaustion() -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3107,6 +3107,12 @@ def test_pytorch_zip_discovery_checks_long_window_before_padding_budget(tmp_path
         b"\x82\x01q\x00N\x9400h\x00)R",
         b"\x82\x01q\x00](NNNe0)R",
         b"(\x82\x01)o",
+        b"(N0\x82\x01o",
+        b"\x82\x01Na",
+        b"\x82\x01NNs",
+        b"\x82\x01(Ne",
+        b"\x82\x01(NNu",
+        b"\x82\x01(N\x90",
     ],
 )
 def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop(executable_candidate: bytes) -> None:
@@ -3122,6 +3128,8 @@ def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop(e
         b"\x82\x010)R",
         b"\x82\x01N)R",
         base64.b64decode("ggEpUg==")[:-1],
+        b"(0\x82\x01o",
+        b"N\x82\x01a",
     ],
 )
 def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shadowed(
@@ -3131,6 +3139,29 @@ def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shad
         benign_candidate,
         [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+def test_pytorch_zip_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    remaining_budget_seen: list[int] = []
+
+    def no_signal(_candidate: bytes, parse_budget_remaining: list[int]) -> bool:
+        remaining_budget_seen.append(parse_budget_remaining[0])
+        PyTorchZipScanner._consume_raw_nested_structural_parse_budget(parse_budget_remaining)
+        return False
+
+    monkeypatch.setattr(
+        PyTorchZipScanner,
+        "_raw_nested_extension_opcode_candidate_has_structural_signal",
+        staticmethod(no_signal),
+    )
+
+    assert not PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(b"\x82\x010" * 4)
+    assert remaining_budget_seen == [
+        pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES,
+        pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES - 1,
+        pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES - 2,
+        pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES - 3,
+    ]
 
 
 def test_pytorch_zip_discovery_charges_detected_expanded_probe_once(tmp_path: Path) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3339,7 +3339,7 @@ def test_pytorch_zip_raw_nested_extension_routes_live_mark_after_context_budget_
 
 
 def test_pytorch_zip_raw_nested_extension_skips_incomplete_opcode_after_budget_noise() -> None:
-    value = (b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)) + b"A" * 10 + b"\x82\x01"
+    value = (b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)) + b"A" * 10 + b"\x82"
 
     assert not PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value)
 
@@ -5159,6 +5159,43 @@ def test_pytorch_zip_discovery_routes_headerless_binary_pickle_after_budget_nois
     )
 
 
+def _budget_exhausted_headerless_extension_literal() -> bytes:
+    payload = b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)
+    return b"C" + bytes([len(payload)]) + payload + b"0\x82\x01"
+
+
+def _budget_exhausted_truncated_inst_literal() -> bytes:
+    padding = b"c" * pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES
+    return padding + b"iposix\nsystem\n"
+
+
+@pytest.mark.parametrize(
+    ("literal", "case_name"),
+    [
+        (_budget_exhausted_headerless_extension_literal(), "extension_after_headerless_literal_budget"),
+        (_budget_exhausted_truncated_inst_literal(), "inst_after_candidate_budget"),
+    ],
+)
+def test_pytorch_zip_discovery_routes_budget_exhausted_storage(
+    tmp_path: Path,
+    literal: bytes,
+    case_name: str,
+) -> None:
+    model_path = tmp_path / f"referenced_{case_name}.pt"
+    storage_blob = _proto0_string_literal(literal)
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+
+
 def test_pytorch_zip_discovery_routes_bytearray8_literal_after_trivial_prefix(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_bytearray8_after_trivial_prefix.pt"
     encoded = base64.b64encode(b"cposix\nsystem\n)R.")
@@ -6347,6 +6384,16 @@ def test_pytorch_zip_discovery_raw_nested_literal_candidates_fail_closed_after_b
 
     assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value) is False
     assert calls == pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES
+
+
+def test_pytorch_zip_raw_nested_literal_routes_extension_operand_after_budget_exhaustion() -> None:
+    assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(
+        _budget_exhausted_headerless_extension_literal()
+    )
+
+
+def test_pytorch_zip_raw_nested_literal_preserves_text_marker_after_budget_exhaustion() -> None:
+    assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(_budget_exhausted_truncated_inst_literal())
 
 
 def test_pytorch_zip_structural_fallback_bounds_binary_opcode_candidates(

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3032,6 +3032,111 @@ def test_pytorch_zip_discovery_scans_extension_opcode_crossing_trusted_probe_bou
     )
 
 
+def test_pytorch_zip_discovery_routes_encoded_extension_with_truncated_operand(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_truncated_extension_operand.pt"
+    storage_blob = b"S'ggFxAIwFeA=='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+
+
+def test_pytorch_zip_discovery_routes_encoded_extension_with_live_mark_context(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_live_mark_extension.pt"
+    storage_blob = b"S'KE4wggEpb/8='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+
+
+def test_pytorch_zip_discovery_routes_nested_mark_extension_context(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_nested_mark_extension.pt"
+    payload = b"(N(N10\x82\x01)o\xff"
+    storage_blob = b"C" + bytes([len(payload)]) + payload + b"."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\x82\x01q\x00\xff",
+        (b"N." * 70) + b"(\x82\x01)R\xff",
+    ],
+)
+def test_pytorch_zip_discovery_routes_encoded_extension_fail_closed_suffixes(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    model_path = tmp_path / "referenced_extension_fail_closed_suffix.pt"
+    storage_blob = b"S'" + base64.b64encode(payload) + b"'\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"(" * 20 + b"\xff" + (b"\x82\x01\xff" * 4) + b"\x82\x01)R.",
+        (b"(" * 10) + b"\xff" + (b"\x82\x01\xff" * 10) + b"cposix\nsystem\n)R.",
+    ],
+)
+def test_pytorch_zip_preserves_later_payload_after_exhausted_extension_context(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    model_path = tmp_path / "referenced_extension_exhausted_context_later_payload.pt"
+    storage_blob = b"C" + bytes([len(payload)]) + payload + b"."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_discovery_scans_repeated_trivial_prefix_crossing_trusted_probe_boundary(
     tmp_path: Path,
 ) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3098,6 +3098,19 @@ def test_pytorch_zip_discovery_checks_long_window_before_padding_budget(tmp_path
     assert budget == [0]
 
 
+def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop() -> None:
+    executable_candidate = base64.b64decode("ggEpUg==")
+
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        executable_candidate,
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+    assert not PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        executable_candidate[:-1],
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+
+
 def test_pytorch_zip_discovery_charges_detected_expanded_probe_once(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_detected_expanded_probe_budget_once.pt"
     malicious_suffix = _malicious_proto0_system_payload()

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3098,15 +3098,37 @@ def test_pytorch_zip_discovery_checks_long_window_before_padding_budget(tmp_path
     assert budget == [0]
 
 
-def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop() -> None:
-    executable_candidate = base64.b64decode("ggEpUg==")
-
+@pytest.mark.parametrize(
+    "executable_candidate",
+    [
+        base64.b64decode("ggEpUg=="),
+        base64.b64decode("ggFOMClS"),
+        base64.b64decode("ggEoTjEpUg=="),
+        b"\x82\x01q\x00N\x9400h\x00)R",
+        b"\x82\x01q\x00](NNNe0)R",
+        b"(\x82\x01)o",
+    ],
+)
+def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop(executable_candidate: bytes) -> None:
     assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
         executable_candidate,
         [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+@pytest.mark.parametrize(
+    "benign_candidate",
+    [
+        b"\x82\x010)R",
+        b"\x82\x01N)R",
+        base64.b64decode("ggEpUg==")[:-1],
+    ],
+)
+def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shadowed(
+    benign_candidate: bytes,
+) -> None:
     assert not PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
-        executable_candidate[:-1],
+        benign_candidate,
         [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
 
@@ -5370,6 +5392,96 @@ def test_pytorch_zip_trusted_storage_routes_headerless_byte_literal_at_entry_gat
         )
 
     assert looks_like_pickle is True
+
+
+@pytest.mark.parametrize(
+    ("encoded_extension_literal", "case_name"),
+    [
+        (b"ggFOMClS", "pop-removes-later-none"),
+        (b"ggEoTjEpUg==", "pop-mark-removes-later-mark"),
+        (base64.b64encode(b"\x82\x01q\x00N\x9400h\x00)R"), "explicit-memo-before-memoize"),
+        (base64.b64encode(b"\x82\x01q\x00](NNNe0)R"), "mark-delimited-appends-before-pop"),
+        (base64.b64encode(b"(\x82\x01)o"), "obj-mark-before-extension"),
+    ],
+)
+def test_pytorch_zip_trusted_storage_routes_encoded_extension_callable_after_pop(
+    tmp_path: Path,
+    encoded_extension_literal: bytes,
+    case_name: str,
+) -> None:
+    archive_path = tmp_path / f"headerless_extension_storage_gate_{case_name}.pt"
+    storage_blob = b"C" + bytes([len(encoded_extension_literal)]) + encoded_extension_literal + b"."
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = ScanResult(scanner_name="pytorch_zip")
+    scanner = PyTorchZipScanner()
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = scanner._trusted_storage_entry_looks_like_pickle(
+            archive,
+            entry,
+            result,
+            padding_probe_bytes_remaining=[pytorch_zip_scanner_module._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+        )
+
+    assert looks_like_pickle is True
+
+
+def test_pytorch_zip_trusted_storage_skips_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
+    archive_path = tmp_path / "headerless_extension_storage_gate_removed.pt"
+    encoded_removed_extension_literal = base64.b64encode(b"\x82\x010)R")
+    storage_blob = b"C" + bytes([len(encoded_removed_extension_literal)]) + encoded_removed_extension_literal + b"."
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = ScanResult(scanner_name="pytorch_zip")
+    scanner = PyTorchZipScanner()
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = scanner._trusted_storage_entry_looks_like_pickle(
+            archive,
+            entry,
+            result,
+            padding_probe_bytes_remaining=[pytorch_zip_scanner_module._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+        )
+
+    assert looks_like_pickle is False
+
+
+@pytest.mark.parametrize(
+    ("payload", "case_name"),
+    [
+        (b"\x82\x01q\x00N\x9400h\x00)R", "memoized_extension"),
+        (b"\x82\x01q\x00](NNNe0)R", "mark_delimited_appends_extension"),
+        (b"(\x82\x01)o", "obj_mark_extension"),
+    ],
+)
+def test_pytorch_zip_scan_routes_extension_callable_in_referenced_storage(
+    tmp_path: Path,
+    payload: bytes,
+    case_name: str,
+) -> None:
+    archive_path = tmp_path / f"{case_name}_storage.pt"
+    storage_blob = b"S'" + base64.b64encode(payload) + b"'\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(archive_path))
+
+    assert result.success is False
+    assert result.metadata.get("pickle_verdict") == "unknown"
+    assert result.metadata.get("pickle_files") == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        issue.rule_code == "S902" and issue.location is not None and "archive/data/0" in issue.location
+        for issue in result.issues
+    )
 
 
 def test_pytorch_zip_trusted_storage_bounds_nested_byte_literal_discovery(tmp_path: Path) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3999,6 +3999,31 @@ def test_pytorch_zip_discovery_routes_nested_extension_reference_literal_storage
     )
 
 
+def test_pytorch_zip_discovery_routes_base64_extension_reduce_literal_storage(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_base64_extension_reduce_literal_pickle.pt"
+    storage_blob = b"S'ggFOMClSLg=='\n."
+    storage_blob += b" " * (-len(storage_blob) % 4)
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert any(
+        issue.rule_code == "S601" and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+    assert any(
+        issue.details.get("pickle_rule_code") == "DANGEROUS_CALL"
+        and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
 @pytest.mark.parametrize(
     ("memo_prefix", "memo_suffix"),
     [

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -2754,6 +2754,24 @@ def test_pytorch_zip_discovery_skips_referenced_storage_blob_pickleish_bytes(tmp
     assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
 
 
+def test_pytorch_zip_discovery_skips_referenced_float_storage_extension_like_bytes(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_float_storage_extension_like_bytes.pt"
+    storage_blob = b"\x8c\x01\xff\x3f\x82\x01\xff\x3f"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "clean"
+    assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
+    assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
+
+
 def test_pytorch_zip_discovery_skips_referenced_yolov5n6_storage_prefix(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_yolov5n6_storage_prefix.pt"
     storage_blob = _yolov5n6_tensor_storage_prefix_bytes()
@@ -3318,6 +3336,52 @@ def test_pytorch_zip_raw_nested_extension_routes_live_mark_after_context_budget_
         [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
     assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value)
+
+
+def test_pytorch_zip_raw_nested_extension_skips_incomplete_opcode_after_budget_noise() -> None:
+    value = (b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1)) + b"A" * 10 + b"\x82\x01"
+
+    assert not PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value)
+
+
+def test_pytorch_zip_raw_nested_extension_routes_later_pickle_after_budget_noise() -> None:
+    nested_pickle = b"\x80\x04\x8c\x08builtins\x8c\x04eval\x93\x8c\x031+1\x85R."
+    value = (
+        (b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1))
+        + b"A" * 10
+        + b"\x82\x01"
+        + (b" " * pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATE_BYTES)
+        + nested_pickle
+    )
+
+    assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value)
+
+
+def test_pytorch_zip_raw_nested_extension_budget_exhaustion_routes_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    value = (
+        (b"c" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 1))
+        + (b"(" * (pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES + 6))
+        + b"\xff"
+        + (b"\x82\x01" * 1900)
+    )
+
+    def fail_if_called(_candidate: bytes) -> bool:
+        raise AssertionError("fallback parser should not run after extension context budget exhaustion")
+
+    monkeypatch.setattr(
+        PyTorchZipScanner,
+        "_extension_candidate_after_exhausted_context_should_scan",
+        staticmethod(fail_if_called),
+    )
+    parse_budget_remaining = [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES]
+
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        value,
+        parse_budget_remaining,
+    )
+    assert parse_budget_remaining == [0]
 
 
 def test_pytorch_zip_raw_nested_extension_routes_headerless_literal_extension_tail() -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3113,6 +3113,8 @@ def test_pytorch_zip_discovery_checks_long_window_before_padding_budget(tmp_path
         b"\x82\x01(Ne",
         b"\x82\x01(NNu",
         b"\x82\x01(N\x90",
+        b"\x82\x01",
+        b"(C\x02(.0\x82\x01o",
     ],
 )
 def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop(executable_candidate: bytes) -> None:
@@ -3125,11 +3127,7 @@ def test_pytorch_zip_routes_raw_nested_extension_reduce_candidate_without_stop(e
 @pytest.mark.parametrize(
     "benign_candidate",
     [
-        b"\x82\x010)R",
-        b"\x82\x01N)R",
-        base64.b64decode("ggEpUg==")[:-1],
-        b"(0\x82\x01o",
-        b"N\x82\x01a",
+        b"(C\x02\x82\x01o",
     ],
 )
 def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shadowed(
@@ -3139,6 +3137,17 @@ def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shad
         benign_candidate,
         [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
     )
+
+
+def test_pytorch_zip_raw_nested_extension_boundary_recovery_charges_shared_budget() -> None:
+    malformed_candidate = b"(" * 256 + b"\xff\x82\x01."
+    parse_budget_remaining = [3]
+
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        malformed_candidate,
+        parse_budget_remaining,
+    )
+    assert parse_budget_remaining == [0]
 
 
 def test_pytorch_zip_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5460,10 +5469,31 @@ def test_pytorch_zip_trusted_storage_routes_encoded_extension_callable_after_pop
     assert looks_like_pickle is True
 
 
-def test_pytorch_zip_trusted_storage_skips_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
-    archive_path = tmp_path / "headerless_extension_storage_gate_removed.pt"
+def test_pytorch_zip_trusted_storage_routes_truncated_encoded_extension_removed_by_pop(tmp_path: Path) -> None:
+    archive_path = tmp_path / "headerless_extension_storage_gate_removed_truncated.pt"
     encoded_removed_extension_literal = base64.b64encode(b"\x82\x010)R")
     storage_blob = b"C" + bytes([len(encoded_removed_extension_literal)]) + encoded_removed_extension_literal + b"."
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data/0", storage_blob)
+
+    result = ScanResult(scanner_name="pytorch_zip")
+    scanner = PyTorchZipScanner()
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        entry = archive.getinfo("archive/data/0")
+        looks_like_pickle = scanner._trusted_storage_entry_looks_like_pickle(
+            archive,
+            entry,
+            result,
+            padding_probe_bytes_remaining=[pytorch_zip_scanner_module._PICKLE_DISCOVERY_LONG_PROBE_BYTES],
+        )
+
+    assert looks_like_pickle is True
+
+
+def test_pytorch_zip_trusted_storage_skips_raw_extension_bytes_in_nonpickle_storage(tmp_path: Path) -> None:
+    archive_path = tmp_path / "headerless_extension_storage_gate_raw_data.pt"
+    storage_blob = b"tensor-storage-bytes:\x82\x01:not-a-pickle"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("archive/data/0", storage_blob)
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -3081,6 +3081,28 @@ def test_pytorch_zip_discovery_routes_nested_mark_extension_context(tmp_path: Pa
     assert "archive/data/0" in result.metadata["pickle_files"]
 
 
+def test_pytorch_zip_discovery_routes_exact_fit_binbytes_storage_without_stop(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_exact_fit_binbytes_without_stop.pt"
+    byte_literal = (b"A" * 5002) + b"cposix\nsystem\n)R."
+    storage_blob = b"B" + len(byte_literal).to_bytes(4, "little") + byte_literal
+    assert len(storage_blob) == 5024
+
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -3112,6 +3134,7 @@ def test_pytorch_zip_discovery_routes_encoded_extension_fail_closed_suffixes(
     [
         b"(" * 20 + b"\xff" + (b"\x82\x01\xff" * 4) + b"\x82\x01)R.",
         (b"(" * 10) + b"\xff" + (b"\x82\x01\xff" * 10) + b"cposix\nsystem\n)R.",
+        (b"(\xff" * pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES) + b"(](NNNe0\x82\x01)o",
     ],
 )
 def test_pytorch_zip_preserves_later_payload_after_exhausted_extension_context(
@@ -3203,6 +3226,26 @@ def test_pytorch_zip_discovery_checks_long_window_before_padding_budget(tmp_path
     assert budget == [0]
 
 
+def test_pytorch_zip_discovery_fails_closed_for_unread_headerless_padding(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_headerless_padding_budget_gap.pt"
+    storage_blob = b"C\x01x." + (b" " * (pytorch_zip_scanner_module._PICKLE_DISCOVERY_PADDING_PROBE_BYTES + 1))
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    scanner = PyTorchZipScanner()
+    result = ScanResult(scanner_name="pytorch_zip")
+    with zipfile.ZipFile(model_path) as zip_file:
+        entry = zip_file.getinfo("archive/data/0")
+        with pytest.raises(ValueError, match="trusted PyTorch storage padding probe limit reached"):
+            scanner._trusted_storage_entry_looks_like_pickle(
+                zip_file,
+                entry,
+                result,
+                max_probe_bytes=pytorch_zip_scanner_module._PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+                padding_probe_bytes_remaining=[2 * pytorch_zip_scanner_module._PICKLE_DISCOVERY_PADDING_PROBE_BYTES],
+            )
+
+
 @pytest.mark.parametrize(
     "executable_candidate",
     [
@@ -3244,6 +3287,18 @@ def test_pytorch_zip_skips_raw_nested_extension_reduce_candidate_removed_or_shad
     )
 
 
+def test_pytorch_zip_routes_unknown_extension_opcode_when_fail_closed_requested() -> None:
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"\x82\x01\xff",
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+        fail_closed_on_unknown_after_extension=True,
+    )
+    assert not PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"\x82\x01\xff",
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+
+
 def test_pytorch_zip_raw_nested_extension_boundary_recovery_charges_shared_budget() -> None:
     malformed_candidate = b"(" * 256 + b"\xff\x82\x01."
     parse_budget_remaining = [3]
@@ -3253,6 +3308,23 @@ def test_pytorch_zip_raw_nested_extension_boundary_recovery_charges_shared_budge
         parse_budget_remaining,
     )
     assert parse_budget_remaining == [0]
+
+
+def test_pytorch_zip_raw_nested_extension_routes_live_mark_after_context_budget_exhaustion() -> None:
+    value = (b"(\xff" * pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES) + b"(](NNNe0\x82\x01)o"
+
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        value,
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
+    assert PyTorchZipScanner._literal_value_has_raw_nested_security_pickle(value)
+
+
+def test_pytorch_zip_raw_nested_extension_routes_headerless_literal_extension_tail() -> None:
+    assert PyTorchZipScanner._raw_nested_extension_opcode_candidate_has_structural_signal(
+        b"C\x01x0\x82\x01",
+        [pytorch_zip_scanner_module._MAX_RAW_NESTED_PICKLE_CANDIDATES],
+    )
 
 
 def test_pytorch_zip_raw_nested_extension_scan_shares_candidate_budget(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pickle_context_filtering.py
+++ b/tests/test_pickle_context_filtering.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import struct
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,26 @@ class SafeStateDict:
 class MaliciousPayload:
     def __reduce__(self) -> tuple[Any, tuple[str]]:
         return (os.system, ("id",))
+
+
+def _short_binunicode(value: bytes) -> bytes:
+    return b"\x8c" + bytes([len(value)]) + value
+
+
+def _alternate_platform_system_payload() -> tuple[bytes, str]:
+    native_module = b"nt" if os.name == "nt" else b"posix"
+    alternate_module = b"posix" if native_module == b"nt" else b"nt"
+    payload = pickle.dumps(
+        {
+            "state_dict": OrderedDict([("layer.weight", "tensor_data")]),
+            "payload": MaliciousPayload(),
+        },
+        protocol=4,
+    )
+    payload = payload.replace(_short_binunicode(native_module), _short_binunicode(alternate_module), 1)
+    if payload.startswith(b"\x80\x04\x95"):
+        payload = payload[:3] + struct.pack("<Q", len(payload) - 11) + payload[11:]
+    return payload, f"{alternate_module.decode()}.system"
 
 
 def test_rust_pickle_scanner_keeps_common_ml_serialization_clean(tmp_path: Path) -> None:
@@ -46,3 +67,18 @@ def test_rust_pickle_scanner_does_not_let_ml_context_hide_dangerous_reduce(tmp_p
         issue.details.get("import_reference") in {"posix.system", "os.system", "nt.system"} for issue in result.issues
     )
     assert not any(issue.details.get("pattern_type") == "setitem_near_dangerous_global" for issue in result.issues)
+
+
+def test_rust_pickle_scanner_keeps_direct_platform_system_detection_complete(tmp_path: Path) -> None:
+    payload, import_reference = _alternate_platform_system_payload()
+    path = tmp_path / "platform-system.pkl"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True, result.to_dict()
+    assert result.metadata.get("analysis_incomplete") is not True
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("import_reference") == import_reference
+        for issue in result.issues
+    )


### PR DESCRIPTION
## Summary
- Preserve PyTorch storage-member scanning when headerless byte literals, encoded literals, padding tails, and EXT1-style nested streams cross probe boundaries.
- Carry forward the previously validated unpublished PR1842 repairs on top of merged main.
- Add inert standalone and root scanner regressions for malicious-positive and benign near-match coverage.

## Validation
- ruff format --check on touched files
- ruff check on touched files
- mypy on touched source/tests
- git diff --check origin/main...HEAD
- pytest packages/modelaudit-picklescan/tests/test_api.py tests/scanners/test_pytorch_zip_scanner.py -q --maxfail=1: 2612 passed, 45 skipped
- native high-risk prepublish review: 3 passes, 0 candidates, receipt reviews/pr-1842-followup-storage-extension/prepublish-4007aceb/prepublish-review-receipt.json

## Notes
- Follow-up to merged #1842; based on current main 7408ed1.
- No model payloads are executed or deserialized by these tests.
