### PR TITLE
fix: avoid C&C signal for check_input_dim identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve call-graph coverage for source-backed builtin aliases and non-canonical stdlib mailbox constructors.
 - Scan all bounded encoded pickle metadata that fits the decoded-byte budget, avoiding incomplete PyTorch ZIP coverage on harmless small encoded tokens.
 - Install `tomli` for Python 3.10 runtime environments so no-default-groups scanner installs can read ModelAudit TOML configuration.
+- Avoid command-and-control false positives for generated TorchScript `_check_input_dim` identifiers while preserving actionable `check_in` detections.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1986,14 +1986,16 @@ def _is_check_input_dim_near_match(data: bytes, match_index: int, token_len: int
     if data[after_index : after_index + len(suffix)] != suffix:
         return False
     after_suffix = after_index + len(suffix)
-    if after_suffix < len(data) and data[after_suffix] in _IDENTIFIER_BYTES:
+    if after_suffix < len(data) and (data[after_suffix] in _IDENTIFIER_BYTES or data[after_suffix] >= 0x80):
         return False
 
-    identifier_start = match_index
-    while identifier_start > 0 and data[identifier_start - 1] in _IDENTIFIER_BYTES:
-        identifier_start -= 1
-    identifier = data[identifier_start : after_index + len(suffix)]
-    return identifier in {b"check_input_dim", b"_check_input_dim"}
+    if match_index > 0 and data[match_index - 1] == ord("_"):
+        before_identifier = match_index - 2 >= 0 and data[match_index - 2] in _IDENTIFIER_BYTES
+        before_unicode = match_index - 2 >= 0 and data[match_index - 2] >= 0x80
+        return not before_identifier and not before_unicode
+    if match_index > 0 and (data[match_index - 1] in _IDENTIFIER_BYTES or data[match_index - 1] >= 0x80):
+        return False
+    return True
 
 
 def _is_ignorable_cc_pattern_near_match(data: bytes, pattern: bytes, match_index: int) -> bool:
@@ -5004,7 +5006,6 @@ class NetworkCommDetector:
         b"phone_home",
         b"check_in",
     ]
-    CC_PATTERNS_REQUIRING_IDENTIFIER_BOUNDARIES: ClassVar[frozenset[bytes]] = frozenset({b"check_in"})
 
     # Suspicious ports
     SUSPICIOUS_PORTS: ClassVar[list[int]] = [

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -189,6 +189,7 @@ _S3_REGIONAL_HOST_PATTERN = re.compile(r"^s3[.-][a-z0-9-]+\.amazonaws\.com$")
 _AZURE_STORAGE_HOST_SUFFIXES = (".blob.core.windows.net", ".dfs.core.windows.net")
 _AZURE_AUTHORITY_CONTAINER_SCHEMES = frozenset({"wasb", "wasbs", "abfs", "abfss"})
 _AZURE_CONTAINER_NAME_PATTERN = re.compile(r"^(?:\$root|[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?)$")
+_IDENTIFIER_BYTES: frozenset[int] = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
 
 
 def _split_trailing_path_delimiters(segment: str) -> tuple[str, str]:
@@ -1977,6 +1978,13 @@ def _iter_pattern_matches(data: bytes, pattern: bytes) -> Iterator[int]:
             break
         yield match_index
         start = match_index + max(1, len(pattern))
+
+
+def _is_identifier_embedded_match(data: bytes, match_index: int, token_len: int) -> bool:
+    before_is_identifier = match_index > 0 and data[match_index - 1] in _IDENTIFIER_BYTES
+    after_index = match_index + token_len
+    after_is_identifier = after_index < len(data) and data[after_index] in _IDENTIFIER_BYTES
+    return before_is_identifier or after_is_identifier
 
 
 def _has_call_syntax(data: bytes, match_index: int, token_len: int) -> bool:
@@ -4983,6 +4991,7 @@ class NetworkCommDetector:
         b"phone_home",
         b"check_in",
     ]
+    CC_PATTERNS_REQUIRING_IDENTIFIER_BOUNDARIES: ClassVar[frozenset[bytes]] = frozenset({b"check_in"})
 
     # Suspicious ports
     SUSPICIOUS_PORTS: ClassVar[list[int]] = [
@@ -6089,32 +6098,35 @@ class NetworkCommDetector:
         """Scan for command & control patterns."""
         lowered_data = data.lower()
         for pattern in self.cc_patterns:
-            idx = lowered_data.find(pattern)
-            if idx < 0:
-                continue
+            for idx in _iter_pattern_matches(lowered_data, pattern):
+                if pattern in self.CC_PATTERNS_REQUIRING_IDENTIFIER_BOUNDARIES and _is_identifier_embedded_match(
+                    data, idx, len(pattern)
+                ):
+                    continue
 
-            snippet = _redacted_snippet_for_match(data, idx, idx + len(pattern), before=30, after=30)
+                snippet = _redacted_snippet_for_match(data, idx, idx + len(pattern), before=30, after=30)
 
-            confidence = 0.8
-            severity = "CRITICAL"
+                confidence = 0.8
+                severity = "CRITICAL"
 
-            # Very suspicious patterns
-            if pattern in [b"malware", b"backdoor", b"trojan", b"botnet"]:
-                confidence = 0.95
+                # Very suspicious patterns
+                if pattern in [b"malware", b"backdoor", b"trojan", b"botnet"]:
+                    confidence = 0.95
 
-            if not self._record_finding(
-                {
-                    "type": "cc_pattern",
-                    "severity": severity,
-                    "confidence": confidence,
-                    "message": f"C&C pattern detected: {pattern.decode()}",
-                    "pattern": pattern.decode(),
-                    "snippet": snippet,
-                    "position": idx,
-                    "context": context,
-                }
-            ):
-                return
+                if not self._record_finding(
+                    {
+                        "type": "cc_pattern",
+                        "severity": severity,
+                        "confidence": confidence,
+                        "message": f"C&C pattern detected: {pattern.decode()}",
+                        "pattern": pattern.decode(),
+                        "snippet": snippet,
+                        "position": idx,
+                        "context": context,
+                    }
+                ):
+                    return
+                break
 
     def _scan_suspicious_ports(self, data: bytes, context: str) -> None:
         """Scan for references to suspicious ports."""

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1993,9 +1993,10 @@ def _is_check_input_dim_near_match(data: bytes, match_index: int, token_len: int
         before_identifier = match_index - 2 >= 0 and data[match_index - 2] in _IDENTIFIER_BYTES
         before_unicode = match_index - 2 >= 0 and data[match_index - 2] >= 0x80
         return not before_identifier and not before_unicode
-    if match_index > 0 and (data[match_index - 1] in _IDENTIFIER_BYTES or data[match_index - 1] >= 0x80):
-        return False
-    return True
+    if match_index == 0:
+        return True
+    before = data[match_index - 1]
+    return before not in _IDENTIFIER_BYTES and before < 0x80
 
 
 def _is_ignorable_cc_pattern_near_match(data: bytes, pattern: bytes, match_index: int) -> bool:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1980,11 +1980,24 @@ def _iter_pattern_matches(data: bytes, pattern: bytes) -> Iterator[int]:
         start = match_index + max(1, len(pattern))
 
 
-def _is_identifier_embedded_match(data: bytes, match_index: int, token_len: int) -> bool:
-    before_is_identifier = match_index > 0 and data[match_index - 1] in _IDENTIFIER_BYTES
+def _is_check_input_dim_near_match(data: bytes, match_index: int, token_len: int) -> bool:
+    suffix = b"put_dim"
     after_index = match_index + token_len
-    after_is_identifier = after_index < len(data) and data[after_index] in _IDENTIFIER_BYTES
-    return before_is_identifier or after_is_identifier
+    if data[after_index : after_index + len(suffix)] != suffix:
+        return False
+    after_suffix = after_index + len(suffix)
+    if after_suffix < len(data) and data[after_suffix] in _IDENTIFIER_BYTES:
+        return False
+
+    identifier_start = match_index
+    while identifier_start > 0 and data[identifier_start - 1] in _IDENTIFIER_BYTES:
+        identifier_start -= 1
+    identifier = data[identifier_start : after_index + len(suffix)]
+    return identifier in {b"check_input_dim", b"_check_input_dim"}
+
+
+def _is_ignorable_cc_pattern_near_match(data: bytes, pattern: bytes, match_index: int) -> bool:
+    return pattern == b"check_in" and _is_check_input_dim_near_match(data, match_index, len(pattern))
 
 
 def _has_call_syntax(data: bytes, match_index: int, token_len: int) -> bool:
@@ -6099,9 +6112,7 @@ class NetworkCommDetector:
         lowered_data = data.lower()
         for pattern in self.cc_patterns:
             for idx in _iter_pattern_matches(lowered_data, pattern):
-                if pattern in self.CC_PATTERNS_REQUIRING_IDENTIFIER_BOUNDARIES and _is_identifier_embedded_match(
-                    data, idx, len(pattern)
-                ):
+                if _is_ignorable_cc_pattern_near_match(lowered_data, pattern, idx):
                     continue
 
                 snippet = _redacted_snippet_for_match(data, idx, idx + len(pattern), before=30, after=30)

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -8666,6 +8666,37 @@ class TestNetworkCommDetector:
         assert not any(finding["type"] == "cc_pattern" and finding["pattern"] == "check_in" for finding in findings)
 
     @pytest.mark.parametrize(
+        "data",
+        [
+            b"_check_in()",
+            b"agent_check_in()",
+            b"check_input_dim_remote()",
+            b"_check_input_dim2()",
+        ],
+    )
+    def test_prefixed_check_in_calls_stay_cc_patterns(self, data: bytes) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, "hook.py")
+
+        assert any(
+            finding["type"] == "cc_pattern" and finding["pattern"] == "check_in" and finding["severity"] == "CRITICAL"
+            for finding in findings
+        )
+
+    def test_check_input_dim_near_match_does_not_hide_later_check_in(self) -> None:
+        detector = NetworkCommDetector()
+        data = b"def _check_input_dim(self, input):\n    pass\nagent_check_in()\n"
+
+        findings = detector.scan(data, "hook.py")
+
+        check_in_findings = [
+            finding for finding in findings if finding["type"] == "cc_pattern" and finding["pattern"] == "check_in"
+        ]
+        assert len(check_in_findings) == 1
+        assert check_in_findings[0]["position"] == data.find(b"check_in", data.find(b"agent_"))
+
+    @pytest.mark.parametrize(
         ("data", "expected_pattern"),
         [
             (b'check_in = "https://evil.example/payload"', "check_in"),

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -8650,6 +8650,44 @@ class TestNetworkCommDetector:
         assert "botnet" in patterns
         assert all(finding.get("position") == data.lower().find(finding["pattern"].encode()) for finding in cc_findings)
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b"def _check_input_dim(self, input):\n    pass\n",
+            b"self._check_input_dim(input)\n",
+            b"check_input_dim = input.dim()\n",
+        ],
+    )
+    def test_check_in_prefix_inside_identifier_is_not_cc_pattern(self, data: bytes) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, "model/code/__torch__/torch/nn/modules/batchnorm.py")
+
+        assert not any(finding["type"] == "cc_pattern" and finding["pattern"] == "check_in" for finding in findings)
+
+    @pytest.mark.parametrize(
+        ("data", "expected_pattern"),
+        [
+            (b'check_in = "https://evil.example/payload"', "check_in"),
+            (b'c2_server = "https://evil.example/payload"', "c2_server"),
+        ],
+    )
+    def test_cc_check_in_and_c2_url_assignments_stay_actionable(
+        self,
+        data: bytes,
+        expected_pattern: str,
+    ) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, "hook.py")
+
+        assert any(
+            finding["type"] == "cc_pattern"
+            and finding["pattern"] == expected_pattern
+            and finding["severity"] == "CRITICAL"
+            for finding in findings
+        )
+
     def test_cc_pattern_scan_reuses_lowered_payload(self) -> None:
         """Reuse one lowercase payload view across all C&C pattern checks."""
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -8672,6 +8672,10 @@ class TestNetworkCommDetector:
             b"agent_check_in()",
             b"check_input_dim_remote()",
             b"_check_input_dim2()",
+            "check_input_dimé()".encode(),
+            "écheck_input_dim()".encode(),
+            "é_check_input_dim()".encode(),
+            b"a" * 8192 + b"check_input_dim()",
         ],
     )
     def test_prefixed_check_in_calls_stay_cc_patterns(self, data: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -12682,6 +12682,48 @@ def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -
     ]
 
 
+def test_pytorch_zip_torchscript_check_input_dim_identifier_is_not_s310(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "batchnorm.pt", with_pickle=False, prefix="model")
+    batchnorm_member = "model/code/__torch__/torch/nn/modules/batchnorm.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            batchnorm_member,
+            "\n".join(
+                [
+                    "class BatchNorm(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  training : bool",
+                    "  def _check_input_dim(self: __torch__.torch.nn.modules.batchnorm.BatchNorm,",
+                    "    input: Tensor) -> NoneType:",
+                    "    pass",
+                    "  def forward(self: __torch__.torch.nn.modules.batchnorm.BatchNorm,",
+                    "    input: Tensor) -> Tensor:",
+                    "    self._check_input_dim(input)",
+                    "    return input",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(f"{batchnorm_member}.debug_pkl", _TORCHSCRIPT_DEBUG_PKL)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert not any(
+        issue.rule_code == "S310"
+        and issue.details.get("type") == "cc_pattern"
+        and issue.details.get("pattern") == "check_in"
+        for issue in result.issues
+    )
+    assert not any(
+        check.rule_code == "S310"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("type") == "cc_pattern"
+        and check.details.get("pattern") == "check_in"
+        for check in result.checks
+    )
+
+
 def test_pytorch_zip_hf_google_bert_rust_model_torchscript_reconstruction_control(tmp_path: Path) -> None:
     model_path = tmp_path / "rust_model.ot"
     with zipfile.ZipFile(model_path, "w") as zip_file:


### PR DESCRIPTION
## Summary

Fixes an S310 false positive where generated TorchScript identifiers such as `_check_input_dim` were treated as the weak C&C token `check_in`.

The suppression is limited to exact `check_input_dim` / `_check_input_dim` near-matches. Prefixed, suffixed, Unicode-adjacent, long-prefix and later `check_in` occurrences remain actionable.

## Validation

- Focused detector/root regressions: 15 passed for benign `_check_input_dim`, prefixed/suffixed `check_in`, Unicode-adjacent controls, long-prefix control, later `check_in`, assignment controls and the TorchScript ZIP root path.
- `git diff --check`: passed.
- Ruff 0.15.10, matching the failing CI lane: full `ruff check modelaudit/ tests/` passed after the additive lint fix.
- `ruff format --check` on touched Python files: passed.
- `py_compile` on touched Python files: passed.
- `mypy --python-version 3.13` on touched Python files: passed.
- Matched-profile real-model QA on pinned `dnouri/spleen_ct_segmentation` revision `7449f9513251dea094b1ca06a5baddc7fbf79ff0`: one Python 3.13 interpreter and one PickleScan source/native extension, varying only root ModelAudit checkout; main S310 12 -> final branch S310 0 with same bytes scanned, checks, scanner set, S510/S601 counts, NON_ALLOWLISTED_GLOBAL count and incomplete-scan signals. Receipt: `reviews/pr-s310-check-input-dim-fp/real-model-qa-dnouri-20260912T110503Z/qa-receipt.json`.
- High-risk native prepublish review for current head `94819ce0eaa1dadcda2a51fc243b94594a958d15`: 3 clean passes plus independent verifier. Receipt: `reviews/pr-s310-check-input-dim-fp/prepublish-94819ce0/prepublish-review-receipt.json` (`74e38e9c77281eed1fb427c96d5133f842945ef52f227deaee0d21a7398642b9`).

## Notes

The dnouri QA remains partial and is not completion credit because unrelated findings and incomplete coverage remain.
